### PR TITLE
Adds WebSocket UDP proxy support

### DIFF
--- a/DataGateOpenVpnManager.Tests/DataGateOpenVpnManager.Tests.csproj
+++ b/DataGateOpenVpnManager.Tests/DataGateOpenVpnManager.Tests.csproj
@@ -9,11 +9,11 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="coverlet.collector" Version="6.0.4">
+        <PackageReference Include="coverlet.collector" Version="8.0.0">
           <PrivateAssets>all</PrivateAssets>
           <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
         </PackageReference>
-        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.0.1" />
+        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.3.0" />
         <PackageReference Include="Moq" Version="4.20.72" />
         <PackageReference Include="xunit" Version="2.9.3" />
         <PackageReference Include="xunit.runner.visualstudio" Version="3.1.5">

--- a/DataGateOpenVpnManager/Configurations/PipelineConfiguration.cs
+++ b/DataGateOpenVpnManager/Configurations/PipelineConfiguration.cs
@@ -1,4 +1,4 @@
-﻿using System.Reflection;
+using System.Reflection;
 using DataGateOpenVpnManager.Hubs;
 
 namespace DataGateOpenVpnManager.Configurations;
@@ -36,35 +36,10 @@ public static class PipelineConfiguration
         app.MapGet("/error/404", () => Results.Problem(statusCode: 404, title: "Page Not Found",
                 detail: "The requested resource was not found."))
             .ExcludeFromDescription();
+        app.MapGet("/", () => Results.Redirect("/api/info")).ExcludeFromDescription();
 
         var version = Assembly.GetExecutingAssembly().GetName().Version?.ToString() ?? "Unknown version";
         var environmentName = app.Environment.EnvironmentName;
-
-        app.MapGet("/", (IConfiguration config) => Results.Json(new
-        {
-            version,
-            environment = environmentName,
-            application = "DataGateOpenVpnManager",
-            description = "This service manages OpenVPN certificates and provides a JSON API for operations like create/revoke.",
-            config = new
-            {
-                dns1 = config["DNS1"],
-                dns2 = config["DNS2"],
-                vpnSubnet = config["VPN_SUBNET"],
-                vpnNetmask = config["VPN_NETMASK"],
-                easyRsaPath = config["EASY_RSA_PATH"],
-                dataDir = config["DATA_DIR"],
-                port = config["PORT"],
-                apiPort = config["API_PORT"],
-                proto = config["PROTO"],
-                openVpnManagement = new
-                {
-                    host = config["OpenVpnManagement:Host"],
-                    port = config["OpenVpnManagement:Port"]
-                },
-                backendBaseUrl = config["BACKEND__BASEURL"]
-            }
-        }));
         app.Logger.LogInformation($"Application version: {version}; Environment: {environmentName};");
         
         //SignalR

--- a/DataGateOpenVpnManager/Controllers/IndexController.cs
+++ b/DataGateOpenVpnManager/Controllers/IndexController.cs
@@ -1,0 +1,54 @@
+using System.Reflection;
+using Microsoft.AspNetCore.Mvc;
+using OpenVPNGateMonitor.SharedModels.DataGateOpenVpnManager.Info;
+
+namespace DataGateOpenVpnManager.Controllers;
+
+[ApiController]
+[Route("api/info")]
+public class IndexController(
+    IConfiguration config,
+    IWebHostEnvironment env,
+    ILogger<IndexController> logger)
+    : ControllerBase
+{
+    [HttpGet]
+    public async Task<ActionResult<RootInfoResponse>> Get(CancellationToken cancellationToken)
+    {
+        try
+        {
+            var version = Assembly.GetExecutingAssembly().GetName().Version?.ToString() ?? "Unknown version";
+            var response = new RootInfoResponse
+            {
+                Version = version,
+                Environment = env.EnvironmentName,
+                Application = "DataGateOpenVpnManager",
+                Description = "This service manages OpenVPN certificates and provides a JSON API for operations like create/revoke.",
+                Config = new ConfigInfoResponse
+                {
+                    Dns1 = config["DNS1"],
+                    Dns2 = config["DNS2"],
+                    VpnSubnet = config["VPN_SUBNET"],
+                    VpnNetmask = config["VPN_NETMASK"],
+                    EasyRsaPath = config["EASY_RSA_PATH"],
+                    DataDir = config["DATA_DIR"],
+                    Port = config["PORT"],
+                    ApiPort = config["API_PORT"],
+                    Proto = config["PROTO"],
+                    OpenVpnManagement = new OpenVpnManagementInfoResponse
+                    {
+                        Host = config["OpenVpnManagement:Host"],
+                        Port = config["OpenVpnManagement:Port"]
+                    },
+                    BackendBaseUrl = config["BACKEND__BASEURL"]
+                }
+            };
+            return Ok(response);
+        }
+        catch (Exception ex)
+        {
+            logger.LogError(ex, "Error getting info");
+            return BadRequest(new { error = ex.Message });
+        }
+    }
+}

--- a/DataGateOpenVpnManager/Controllers/OpenVpnProxyController.cs
+++ b/DataGateOpenVpnManager/Controllers/OpenVpnProxyController.cs
@@ -12,6 +12,9 @@ public class OpenVpnProxyController(
     ILogger<OpenVpnProxyController> logger)
     : ControllerBase
 {
+    private const int MaxUdpDatagramSize = 64 * 1024;
+    private const int WsSegmentSize = 16 * 1024;
+
     [HttpGet]
     public async Task Get([FromQuery] string? mode = null)
     {
@@ -31,7 +34,7 @@ public class OpenVpnProxyController(
         }
 
         const string targetHost = "127.0.0.1";
-        var targetIp = IPAddress.Parse(targetHost);
+        var targetIp = IPAddress.Loopback;
 
         using var ws = await HttpContext.WebSockets.AcceptWebSocketAsync();
 
@@ -43,13 +46,9 @@ public class OpenVpnProxyController(
         try
         {
             if (modeNorm == "udp")
-            {
                 await HandleUdp(ws, targetIp, vpnPort, linkedCts.Token, logger);
-            }
             else
-            {
                 await HandleTcp(ws, targetHost, vpnPort, linkedCts.Token, logger);
-            }
         }
         catch (OperationCanceledException)
         {
@@ -80,6 +79,7 @@ public class OpenVpnProxyController(
     {
         using var tcp = new TcpClient();
         tcp.NoDelay = true;
+
         try
         {
             await tcp.ConnectAsync(targetHost, vpnPort, ct);
@@ -87,17 +87,7 @@ public class OpenVpnProxyController(
         catch (Exception e)
         {
             logger.LogError(e, "TCP connect failed. {Host}:{Port}. {Message}", targetHost, vpnPort, e.Message);
-
-            try
-            {
-                if (ws.State == WebSocketState.Open)
-                    await ws.CloseAsync(WebSocketCloseStatus.InternalServerError, "TCP connect failed", CancellationToken.None);
-            }
-            catch (Exception ex)
-            {
-                logger.LogTrace("WebSocket close failed. {Message}", ex.Message);
-            }
-
+            await TryCloseWs(ws, "TCP connect failed", logger);
             return;
         }
 
@@ -119,6 +109,11 @@ public class OpenVpnProxyController(
         var remote = new IPEndPoint(targetIp, vpnPort);
 
         using var udp = new UdpClient(0);
+
+        // Helps with bursts; adjust if you see memory pressure.
+        udp.Client.SendBufferSize = 4 * 1024 * 1024;
+        udp.Client.ReceiveBufferSize = 4 * 1024 * 1024;
+
         try
         {
             udp.Connect(remote);
@@ -126,50 +121,65 @@ public class OpenVpnProxyController(
         catch (Exception e)
         {
             logger.LogError(e, "UDP connect failed. {Host}:{Port}. {Message}", remote.Address, remote.Port, e.Message);
-
-            try
-            {
-                if (ws.State == WebSocketState.Open)
-                    await ws.CloseAsync(WebSocketCloseStatus.InternalServerError, "UDP connect failed", CancellationToken.None);
-            }
-            catch (Exception ex)
-            {
-                logger.LogTrace("WebSocket close failed. {Message}", ex.Message);
-            }
-
+            await TryCloseWs(ws, "UDP connect failed", logger);
             return;
         }
 
-        // WS -> UDP
+        logger.LogInformation("UDP proxy started. remote={Remote} local={Local}",
+            remote, udp.Client.LocalEndPoint);
+
+        // WS -> UDP (supports WS fragmentation)
         var wsToUdp = Task.Run(async () =>
         {
-            var buffer = new byte[64 * 1024];
+            var segment = new byte[WsSegmentSize];
+            var datagram = new byte[MaxUdpDatagramSize];
 
             try
             {
                 while (!ct.IsCancellationRequested && ws.State == WebSocketState.Open)
                 {
-                    var result = await ws.ReceiveAsync(buffer, ct);
+                    var total = 0;
 
-                    if (result.MessageType == WebSocketMessageType.Close)
-                        break;
-
-                    if (result.MessageType != WebSocketMessageType.Binary)
-                        continue;
-
-                    // We require one WS binary message = one UDP datagram.
-                    if (!result.EndOfMessage)
+                    while (true)
                     {
-                        // Drain remaining fragments to keep the stream consistent.
-                        while (!result.EndOfMessage)
-                            result = await ws.ReceiveAsync(buffer, ct);
+                        var result = await ws.ReceiveAsync(segment, ct);
 
-                        logger.LogDebug("Fragmented WS binary message is not supported in UDP mode.");
-                        break;
+                        if (result.MessageType == WebSocketMessageType.Close)
+                            return;
+
+                        if (result.MessageType != WebSocketMessageType.Binary)
+                        {
+                            // Drain remainder of this message (if fragmented), then ignore it.
+                            while (!result.EndOfMessage)
+                                result = await ws.ReceiveAsync(segment, ct);
+
+                            total = 0;
+                            break;
+                        }
+
+                        if (result.Count > 0)
+                        {
+                            if (total + result.Count > datagram.Length)
+                            {
+                                logger.LogWarning("WS binary message exceeds UDP max size ({Max}). Dropping.", MaxUdpDatagramSize);
+
+                                while (!result.EndOfMessage)
+                                    result = await ws.ReceiveAsync(segment, ct);
+
+                                total = 0;
+                                break;
+                            }
+
+                            Buffer.BlockCopy(segment, 0, datagram, total, result.Count);
+                            total += result.Count;
+                        }
+
+                        if (result.EndOfMessage)
+                            break;
                     }
 
-                    if (result.Count > 0)
-                        await udp.SendAsync(buffer.AsMemory(0, result.Count), ct);
+                    if (total > 0)
+                        await udp.SendAsync(datagram.AsMemory(0, total), ct);
                 }
             }
             catch (OperationCanceledException)
@@ -216,6 +226,21 @@ public class OpenVpnProxyController(
         }, ct);
 
         await Task.WhenAny(wsToUdp, udpToWs);
+
+        logger.LogInformation("UDP proxy stopped. remote={Remote}", remote);
+    }
+
+    private static async Task TryCloseWs(WebSocket ws, string reason, ILogger logger)
+    {
+        try
+        {
+            if (ws.State == WebSocketState.Open)
+                await ws.CloseAsync(WebSocketCloseStatus.InternalServerError, reason, CancellationToken.None);
+        }
+        catch (Exception ex)
+        {
+            logger.LogTrace("WebSocket close failed. {Message}", ex.Message);
+        }
     }
 
     private static async Task PumpWebSocketToTcp(
@@ -249,7 +274,8 @@ public class OpenVpnProxyController(
                     await tcp.WriteAsync(buffer.AsMemory(0, result.Count), ct);
                 }
 
-                await tcp.FlushAsync(ct);
+                // NetworkStream flush is typically unnecessary and may hurt throughput/latency.
+                // await tcp.FlushAsync(ct);
             }
         }
         catch (OperationCanceledException ex)

--- a/DataGateOpenVpnManager/Controllers/OpenVpnProxyController.cs
+++ b/DataGateOpenVpnManager/Controllers/OpenVpnProxyController.cs
@@ -1,4 +1,5 @@
-﻿using System.Net.Sockets;
+﻿using System.Net;
+using System.Net.Sockets;
 using System.Net.WebSockets;
 using Microsoft.AspNetCore.Mvc;
 
@@ -12,7 +13,7 @@ public class OpenVpnProxyController(
     : ControllerBase
 {
     [HttpGet]
-    public async Task Get()
+    public async Task Get([FromQuery] string? mode = null)
     {
         if (!HttpContext.WebSockets.IsWebSocketRequest)
         {
@@ -30,13 +31,58 @@ public class OpenVpnProxyController(
         }
 
         const string targetHost = "127.0.0.1";
+        var targetIp = IPAddress.Parse(targetHost);
 
         using var ws = await HttpContext.WebSockets.AcceptWebSocketAsync();
 
-        using var tcp = new TcpClient { NoDelay = true };
+        var ct = HttpContext.RequestAborted;
+        using var linkedCts = CancellationTokenSource.CreateLinkedTokenSource(ct);
+
+        var modeNorm = (mode ?? "tcp").Trim().ToLowerInvariant();
+
         try
         {
-            await tcp.ConnectAsync(targetHost, vpnPort);
+            if (modeNorm == "udp")
+            {
+                await HandleUdp(ws, targetIp, vpnPort, linkedCts.Token, logger);
+            }
+            else
+            {
+                await HandleTcp(ws, targetHost, vpnPort, linkedCts.Token, logger);
+            }
+        }
+        catch (OperationCanceledException)
+        {
+            // ignore
+        }
+        catch (Exception e)
+        {
+            logger.LogDebug(e, "Proxy failed. mode={Mode} {Message}", modeNorm, e.Message);
+        }
+
+        try
+        {
+            if (ws.State == WebSocketState.Open)
+                await ws.CloseAsync(WebSocketCloseStatus.NormalClosure, "Closing", CancellationToken.None);
+        }
+        catch (Exception e)
+        {
+            logger.LogDebug(e, "WebSocket close error. {Message}", e.Message);
+        }
+    }
+
+    private static async Task HandleTcp(
+        WebSocket ws,
+        string targetHost,
+        int vpnPort,
+        CancellationToken ct,
+        ILogger logger)
+    {
+        using var tcp = new TcpClient();
+        tcp.NoDelay = true;
+        try
+        {
+            await tcp.ConnectAsync(targetHost, vpnPort, ct);
         }
         catch (Exception e)
         {
@@ -45,13 +91,11 @@ public class OpenVpnProxyController(
             try
             {
                 if (ws.State == WebSocketState.Open)
-                {
                     await ws.CloseAsync(WebSocketCloseStatus.InternalServerError, "TCP connect failed", CancellationToken.None);
-                }
             }
             catch (Exception ex)
             {
-                logger.LogTrace("Something went wrong. When ... {Message}", ex.Message);
+                logger.LogTrace("WebSocket close failed. {Message}", ex.Message);
             }
 
             return;
@@ -59,35 +103,119 @@ public class OpenVpnProxyController(
 
         await using var tcpStream = tcp.GetStream();
 
-        var ct = HttpContext.RequestAborted;
-        using var linkedCts = CancellationTokenSource.CreateLinkedTokenSource(ct);
-
-        var wsToTcp = PumpWebSocketToTcp(ws, tcpStream, linkedCts.Token, logger);
-        var tcpToWs = PumpTcpToWebSocket(ws, tcpStream, linkedCts.Token, logger);
+        var wsToTcp = PumpWebSocketToTcp(ws, tcpStream, ct, logger);
+        var tcpToWs = PumpTcpToWebSocket(ws, tcpStream, ct, logger);
 
         await Task.WhenAny(wsToTcp, tcpToWs);
-        await linkedCts.CancelAsync();
+    }
 
+    private static async Task HandleUdp(
+        WebSocket ws,
+        IPAddress targetIp,
+        int vpnPort,
+        CancellationToken ct,
+        ILogger logger)
+    {
+        var remote = new IPEndPoint(targetIp, vpnPort);
+
+        using var udp = new UdpClient(0);
         try
         {
-            await Task.WhenAll(wsToTcp, tcpToWs);
-        }
-        catch (Exception ex)
-        {
-            logger.LogTrace("Something went wrong. {Message}", ex.Message);
-        }
-
-        try
-        {
-            if (ws.State == WebSocketState.Open)
-            {
-                await ws.CloseAsync(WebSocketCloseStatus.NormalClosure, "Closing", CancellationToken.None);
-            }
+            udp.Connect(remote);
         }
         catch (Exception e)
         {
-            logger.LogDebug(e, "WebSocket close error. {Message}", e.Message);
+            logger.LogError(e, "UDP connect failed. {Host}:{Port}. {Message}", remote.Address, remote.Port, e.Message);
+
+            try
+            {
+                if (ws.State == WebSocketState.Open)
+                    await ws.CloseAsync(WebSocketCloseStatus.InternalServerError, "UDP connect failed", CancellationToken.None);
+            }
+            catch (Exception ex)
+            {
+                logger.LogTrace("WebSocket close failed. {Message}", ex.Message);
+            }
+
+            return;
         }
+
+        // WS -> UDP
+        var wsToUdp = Task.Run(async () =>
+        {
+            var buffer = new byte[64 * 1024];
+
+            try
+            {
+                while (!ct.IsCancellationRequested && ws.State == WebSocketState.Open)
+                {
+                    var result = await ws.ReceiveAsync(buffer, ct);
+
+                    if (result.MessageType == WebSocketMessageType.Close)
+                        break;
+
+                    if (result.MessageType != WebSocketMessageType.Binary)
+                        continue;
+
+                    // We require one WS binary message = one UDP datagram.
+                    if (!result.EndOfMessage)
+                    {
+                        // Drain remaining fragments to keep the stream consistent.
+                        while (!result.EndOfMessage)
+                            result = await ws.ReceiveAsync(buffer, ct);
+
+                        logger.LogDebug("Fragmented WS binary message is not supported in UDP mode.");
+                        break;
+                    }
+
+                    if (result.Count > 0)
+                        await udp.SendAsync(buffer.AsMemory(0, result.Count), ct);
+                }
+            }
+            catch (OperationCanceledException)
+            {
+                // ignore
+            }
+            catch (Exception e)
+            {
+                logger.LogDebug(e, "WS->UDP pump error. {Message}", e.Message);
+            }
+        }, ct);
+
+        // UDP -> WS
+        var udpToWs = Task.Run(async () =>
+        {
+            try
+            {
+                while (!ct.IsCancellationRequested && ws.State == WebSocketState.Open)
+                {
+                    var pkt = await udp.ReceiveAsync(ct);
+                    if (pkt.Buffer.Length <= 0)
+                        continue;
+
+                    await ws.SendAsync(
+                        pkt.Buffer,
+                        WebSocketMessageType.Binary,
+                        endOfMessage: true,
+                        cancellationToken: ct
+                    );
+                }
+            }
+            catch (OperationCanceledException)
+            {
+                // ignore
+            }
+            catch (SocketException e)
+            {
+                logger.LogDebug(e, "UDP receive error. {Message}", e.Message);
+            }
+            catch (Exception e)
+            {
+                logger.LogDebug(e, "UDP->WS pump error. {Message}", e.Message);
+            }
+        }, ct);
+
+        await Task.WhenAny(wsToUdp, udpToWs);
     }
 
     private static async Task PumpWebSocketToTcp(

--- a/DataGateOpenVpnManager/Controllers/OpenVpnProxyController.cs
+++ b/DataGateOpenVpnManager/Controllers/OpenVpnProxyController.cs
@@ -109,82 +109,66 @@ public class OpenVpnProxyController(
         var remote = new IPEndPoint(targetIp, vpnPort);
 
         using var udp = new UdpClient(0);
-
-        // Helps with bursts; adjust if you see memory pressure.
-        udp.Client.SendBufferSize = 4 * 1024 * 1024;
-        udp.Client.ReceiveBufferSize = 4 * 1024 * 1024;
-
         try
         {
             udp.Connect(remote);
+            logger.LogInformation("UDP proxy started. remote={Remote} local={Local}", remote, udp.Client.LocalEndPoint);
         }
         catch (Exception e)
         {
             logger.LogError(e, "UDP connect failed. {Host}:{Port}. {Message}", remote.Address, remote.Port, e.Message);
-            await TryCloseWs(ws, "UDP connect failed", logger);
+            if (ws.State == WebSocketState.Open)
+                await SafeCloseWs(ws, WebSocketCloseStatus.InternalServerError, "UDP connect failed");
             return;
         }
 
-        logger.LogInformation("UDP proxy started. remote={Remote} local={Local}",
-            remote, udp.Client.LocalEndPoint);
+        // Optional: read and ignore app-level "connect" JSON message (text)
+        // Your C++ bridge sends it right after handshake.
+        await TryDrainOptionalConnectMessage(ws, ct, logger);
 
-        // WS -> UDP (supports WS fragmentation)
         var wsToUdp = Task.Run(async () =>
         {
-            var segment = new byte[WsSegmentSize];
-            var datagram = new byte[MaxUdpDatagramSize];
-
             try
             {
                 while (!ct.IsCancellationRequested && ws.State == WebSocketState.Open)
                 {
-                    var total = 0;
+                    var msg = await ReceiveWholeWsMessage(ws, ct);
+                    logger.LogInformation("WS message: type={Type} bytes={Bytes}", msg.MessageType, msg.Payload.Length);
+                    if (msg.MessageType == WebSocketMessageType.Close)
+                        break;
 
-                    while (true)
+                    if (msg.MessageType == WebSocketMessageType.Text)
                     {
-                        var result = await ws.ReceiveAsync(segment, ct);
-
-                        if (result.MessageType == WebSocketMessageType.Close)
-                            return;
-
-                        if (result.MessageType != WebSocketMessageType.Binary)
-                        {
-                            // Drain remainder of this message (if fragmented), then ignore it.
-                            while (!result.EndOfMessage)
-                                result = await ws.ReceiveAsync(segment, ct);
-
-                            total = 0;
-                            break;
-                        }
-
-                        if (result.Count > 0)
-                        {
-                            if (total + result.Count > datagram.Length)
-                            {
-                                logger.LogWarning("WS binary message exceeds UDP max size ({Max}). Dropping.", MaxUdpDatagramSize);
-
-                                while (!result.EndOfMessage)
-                                    result = await ws.ReceiveAsync(segment, ct);
-
-                                total = 0;
-                                break;
-                            }
-
-                            Buffer.BlockCopy(segment, 0, datagram, total, result.Count);
-                            total += result.Count;
-                        }
-
-                        if (result.EndOfMessage)
-                            break;
+                        // Ignore any text control messages
+                        continue;
                     }
 
-                    if (total > 0)
-                        await udp.SendAsync(datagram.AsMemory(0, total), ct);
+                    if (msg.MessageType != WebSocketMessageType.Binary || msg.Payload.Length == 0)
+                        continue;
+
+                    // Parse one or more datagrams from: [u16_be len][payload]...
+                    var data = msg.Payload;
+                    var off = 0;
+
+                    while (off + 2 <= data.Length)
+                    {
+                        var len = (data[off] << 8) | data[off + 1];
+                        off += 2;
+
+                        if (len <= 0 || off + len > data.Length)
+                        {
+                            logger.LogWarning("Invalid framed UDP message. off={Off} len={Len} total={Total}", off, len,
+                                data.Length);
+                            break;
+                        }
+
+                        await udp.SendAsync(data.AsMemory(off, len), ct);
+                        off += len;
+                    }
                 }
             }
             catch (OperationCanceledException)
             {
-                // ignore
             }
             catch (Exception e)
             {
@@ -192,7 +176,6 @@ public class OpenVpnProxyController(
             }
         }, ct);
 
-        // UDP -> WS
         var udpToWs = Task.Run(async () =>
         {
             try
@@ -203,17 +186,24 @@ public class OpenVpnProxyController(
                     if (pkt.Buffer.Length <= 0)
                         continue;
 
+                    if (pkt.Buffer.Length > 65535)
+                        continue;
+
+                    // Frame: [u16_be len][payload]
+                    var framed = new byte[2 + pkt.Buffer.Length];
+                    framed[0] = (byte)((pkt.Buffer.Length >> 8) & 0xFF);
+                    framed[1] = (byte)(pkt.Buffer.Length & 0xFF);
+                    Buffer.BlockCopy(pkt.Buffer, 0, framed, 2, pkt.Buffer.Length);
+
                     await ws.SendAsync(
-                        pkt.Buffer,
+                        framed,
                         WebSocketMessageType.Binary,
                         endOfMessage: true,
-                        cancellationToken: ct
-                    );
+                        cancellationToken: ct);
                 }
             }
             catch (OperationCanceledException)
             {
-                // ignore
             }
             catch (SocketException e)
             {
@@ -227,7 +217,81 @@ public class OpenVpnProxyController(
 
         await Task.WhenAny(wsToUdp, udpToWs);
 
-        logger.LogInformation("UDP proxy stopped. remote={Remote}", remote);
+        if (ws.State == WebSocketState.Open)
+            await SafeCloseWs(ws, WebSocketCloseStatus.NormalClosure, "Closing");
+    }
+
+    private static async Task SafeCloseWs(WebSocket ws, WebSocketCloseStatus status, string reason)
+    {
+        try
+        {
+            await ws.CloseAsync(status, reason, CancellationToken.None);
+        }
+        catch
+        {
+        }
+    }
+
+    private sealed record WsWholeMessage(WebSocketMessageType MessageType, byte[] Payload);
+
+    private static async Task<WsWholeMessage> ReceiveWholeWsMessage(WebSocket ws, CancellationToken ct)
+    {
+        // Reassembles fragmented WebSocket messages into one payload.
+        var buffer = new byte[16 * 1024];
+        using var ms = new MemoryStream();
+
+        WebSocketReceiveResult result;
+        do
+        {
+            result = await ws.ReceiveAsync(buffer, ct);
+
+            if (result.MessageType == WebSocketMessageType.Close)
+                return new WsWholeMessage(WebSocketMessageType.Close, Array.Empty<byte>());
+
+            if (result.Count > 0)
+                ms.Write(buffer, 0, result.Count);
+        } while (!result.EndOfMessage);
+
+        return new WsWholeMessage(result.MessageType, ms.ToArray());
+    }
+
+    private static async Task TryDrainOptionalConnectMessage(WebSocket ws, CancellationToken ct, ILogger logger)
+    {
+        // The C++ bridge sends a text JSON immediately after handshake:
+        // {"type":"connect","proto":"udp","host":"...","port":...}
+        // Your proxy does not need it. We can safely ignore it if present.
+        if (ws.State != WebSocketState.Open)
+            return;
+
+        using var cts = CancellationTokenSource.CreateLinkedTokenSource(ct);
+        cts.CancelAfter(TimeSpan.FromMilliseconds(250));
+
+        try
+        {
+            var msg = await ReceiveWholeWsMessage(ws, cts.Token);
+            if (msg.MessageType == WebSocketMessageType.Text && msg.Payload.Length > 0)
+            {
+                var text = System.Text.Encoding.UTF8.GetString(msg.Payload);
+                if (text.Contains("\"type\":\"connect\""))
+                    logger.LogInformation("Ignored connect control message: {Text}", text);
+                else
+                    logger.LogInformation("Ignored unexpected text message: {Text}", text);
+            }
+            else if (msg.MessageType == WebSocketMessageType.Binary)
+            {
+                // If first message is binary, it is real traffic. Put it back is not possible,
+                // so we just do nothing here (and rely on normal loop in HandleUdp).
+                // In practice, C++ sends text first, so this should rarely happen.
+            }
+        }
+        catch (OperationCanceledException)
+        {
+            // No message within 250ms - fine.
+        }
+        catch (Exception e)
+        {
+            logger.LogDebug(e, "Failed to drain optional connect message. {Message}", e.Message);
+        }
     }
 
     private static async Task TryCloseWs(WebSocket ws, string reason, ILogger logger)

--- a/DataGateOpenVpnManager/DataGateOpenVpnManager.csproj
+++ b/DataGateOpenVpnManager/DataGateOpenVpnManager.csproj
@@ -5,14 +5,14 @@
         <Nullable>enable</Nullable>
         <ImplicitUsings>enable</ImplicitUsings>
         <ApplicationIcon>wwwroot\favicon.ico</ApplicationIcon>
-        <AssemblyVersion>1.2.5.44</AssemblyVersion>
-        <FileVersion>1.2.5.44</FileVersion>
+        <AssemblyVersion>1.2.5.45</AssemblyVersion>
+        <FileVersion>1.2.5.45</FileVersion>
         <RootNamespace>DataGateOpenVpnManager</RootNamespace>
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="Elastic.Clients.Elasticsearch" Version="9.2.2" />
-        <PackageReference Include="Microsoft.AspNetCore.OpenApi" Version="10.0.1" />
+        <PackageReference Include="Elastic.Clients.Elasticsearch" Version="9.2.3" />
+        <PackageReference Include="Microsoft.AspNetCore.OpenApi" Version="10.0.2" />
         <PackageReference Include="Newtonsoft.Json" Version="13.0.4" />
         <PackageReference Include="OpenVPNGateMonitor.SharedModels" Version="1.0.76" />
         <PackageReference Include="Serilog" Version="4.3.0" />

--- a/DataGateOpenVpnManager/DataGateOpenVpnManager.csproj
+++ b/DataGateOpenVpnManager/DataGateOpenVpnManager.csproj
@@ -5,23 +5,23 @@
         <Nullable>enable</Nullable>
         <ImplicitUsings>enable</ImplicitUsings>
         <ApplicationIcon>wwwroot\favicon.ico</ApplicationIcon>
-        <AssemblyVersion>1.2.5.47</AssemblyVersion>
-        <FileVersion>1.2.5.47</FileVersion>
+        <AssemblyVersion>1.2.5.48</AssemblyVersion>
+        <FileVersion>1.2.5.48</FileVersion>
         <RootNamespace>DataGateOpenVpnManager</RootNamespace>
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="Elastic.Clients.Elasticsearch" Version="9.2.3" />
-        <PackageReference Include="Microsoft.AspNetCore.OpenApi" Version="10.0.2" />
+        <PackageReference Include="Elastic.Clients.Elasticsearch" Version="9.3.1" />
+        <PackageReference Include="Microsoft.AspNetCore.OpenApi" Version="10.0.3" />
         <PackageReference Include="Newtonsoft.Json" Version="13.0.4" />
-        <PackageReference Include="OpenVPNGateMonitor.SharedModels" Version="1.0.76" />
-        <PackageReference Include="Serilog" Version="4.3.0" />
+        <PackageReference Include="OpenVPNGateMonitor.SharedModels" Version="1.0.89" />
+        <PackageReference Include="Serilog" Version="4.3.1" />
         <PackageReference Include="Serilog.Extensions.Hosting" Version="10.0.0" />
         <PackageReference Include="Serilog.Extensions.Logging" Version="10.0.0" />
         <PackageReference Include="Serilog.Sinks.Console" Version="6.1.1" />
         <PackageReference Include="Serilog.Sinks.Elasticsearch" Version="10.0.0" />
-        <PackageReference Include="Swashbuckle.AspNetCore" Version="10.1.0" />
-        <PackageReference Include="System.IdentityModel.Tokens.Jwt" Version="8.15.0" />
+        <PackageReference Include="Swashbuckle.AspNetCore" Version="10.1.4" />
+        <PackageReference Include="System.IdentityModel.Tokens.Jwt" Version="8.16.0" />
     </ItemGroup>
 
     <ItemGroup>

--- a/DataGateOpenVpnManager/DataGateOpenVpnManager.csproj
+++ b/DataGateOpenVpnManager/DataGateOpenVpnManager.csproj
@@ -5,8 +5,8 @@
         <Nullable>enable</Nullable>
         <ImplicitUsings>enable</ImplicitUsings>
         <ApplicationIcon>wwwroot\favicon.ico</ApplicationIcon>
-        <AssemblyVersion>1.2.5.46</AssemblyVersion>
-        <FileVersion>1.2.5.46</FileVersion>
+        <AssemblyVersion>1.2.5.47</AssemblyVersion>
+        <FileVersion>1.2.5.47</FileVersion>
         <RootNamespace>DataGateOpenVpnManager</RootNamespace>
     </PropertyGroup>
 

--- a/DataGateOpenVpnManager/DataGateOpenVpnManager.csproj
+++ b/DataGateOpenVpnManager/DataGateOpenVpnManager.csproj
@@ -5,8 +5,8 @@
         <Nullable>enable</Nullable>
         <ImplicitUsings>enable</ImplicitUsings>
         <ApplicationIcon>wwwroot\favicon.ico</ApplicationIcon>
-        <AssemblyVersion>1.2.5.45</AssemblyVersion>
-        <FileVersion>1.2.5.45</FileVersion>
+        <AssemblyVersion>1.2.5.46</AssemblyVersion>
+        <FileVersion>1.2.5.46</FileVersion>
         <RootNamespace>DataGateOpenVpnManager</RootNamespace>
     </PropertyGroup>
 

--- a/DataGateOpenVpnManager/Hubs/OpenVpnSignalHub.cs
+++ b/DataGateOpenVpnManager/Hubs/OpenVpnSignalHub.cs
@@ -1,4 +1,4 @@
-﻿using System.Collections.Concurrent;
+using System.Collections.Concurrent;
 using DataGateOpenVpnManager.Services.OpenVpnTelnet;
 using DataGateOpenVpnManager.Services.OpenVpnTelnet.Subscribers;
 using Microsoft.AspNetCore.SignalR;
@@ -81,7 +81,8 @@ public class OpenVpnSignalHub(
         catch (Exception ex)
         {
             logger.LogError(ex, "SendCommand failed for {ConnectionId}", Context.ConnectionId);
-            throw;
+            // Rethrow only the message so SignalR does not try to serialize Exception (e.g. IntPtr in WaitHandle)
+            throw new HubException(ex.Message);
         }
     }
 
@@ -99,7 +100,8 @@ public class OpenVpnSignalHub(
         {
             logger.LogError(ex, "SendCommandWithRequestId failed for {ConnectionId}, RequestId={RequestId}",
                 Context.ConnectionId, requestId);
-            throw;
+            // Rethrow only the message so SignalR does not try to serialize Exception (e.g. IntPtr in WaitHandle)
+            throw new HubException(ex.Message);
         }
     }
 }


### PR DESCRIPTION
Enhances the OpenVPN proxy by introducing support for UDP traffic over WebSockets. This allows for more flexible VPN deployments, especially for UDP-based connections.

Key changes include:
- **WebSocket UDP Proxy:** Implements a robust UDP proxy mode via the existing `/proxy` endpoint using a `mode=udp` query parameter. It features proper framing of UDP datagrams and reassembly of fragmented WebSocket messages for reliable communication.
- **Info Endpoint Refactor:** Moves the application's root information endpoint to a new `/api/info` controller, improving API structure and maintainability. The root path now redirects to this new endpoint.
- **Dependency Updates:** Updates various NuGet packages across the solution to their latest versions, ensuring improved stability, security, and compatibility.
- **SignalR Error Handling:** Modifies SignalR hub exception handling to prevent serialization issues with complex exception objects by throwing a simplified `HubException` message.