### PR TITLE
fix: harden proxy TCP/UDP flow handling and add load integration coverage

### DIFF
--- a/DataGateOpenVpnManager.Tests/Configurations/ServiceConfigurationTests.cs
+++ b/DataGateOpenVpnManager.Tests/Configurations/ServiceConfigurationTests.cs
@@ -86,8 +86,16 @@ public class ServiceConfigurationTests
         var active2 = provider.GetRequiredService<IActiveProxyConnectionService>();
         Assert.Same(active1, active2);
 
+        var identity1 = provider.GetRequiredService<IProxyConnectionIdentityResolver>();
+        var identity2 = provider.GetRequiredService<IProxyConnectionIdentityResolver>();
+        Assert.Same(identity1, identity2);
+
         var history1 = provider.GetRequiredService<IProxyConnectionHistoryService>();
         var history2 = provider.GetRequiredService<IProxyConnectionHistoryService>();
         Assert.Same(history1, history2);
+
+        var flow1 = provider.GetRequiredService<IProxyTrafficFlowService>();
+        var flow2 = provider.GetRequiredService<IProxyTrafficFlowService>();
+        Assert.Same(flow1, flow2);
     }
 }

--- a/DataGateOpenVpnManager.Tests/Controllers/OpenVpnProxyControllerIntegrationTests.cs
+++ b/DataGateOpenVpnManager.Tests/Controllers/OpenVpnProxyControllerIntegrationTests.cs
@@ -1,0 +1,250 @@
+using System.Net.Sockets;
+using System.Net.WebSockets;
+using DataGateOpenVpnManager.Controllers;
+using DataGateOpenVpnManager.Services.Proxy;
+using DataGateMonitor.SharedModels.DataGateOpenVpnManager.Proxy;
+using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Hosting;
+using Microsoft.AspNetCore.TestHost;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging.Abstractions;
+
+namespace DataGateOpenVpnManager.Tests.Controllers;
+
+public class OpenVpnProxyControllerIntegrationTests
+{
+    [Theory]
+    [InlineData(10 * 1024 * 1024)]
+    public async Task TcpProxy_RoundTripsPayload_AndRecordsTraffic(int payloadBytes)
+    {
+        await using var echo = await TcpEchoServer.StartAsync();
+        var (server, active, flow) = CreateProxyTestServer(echo.Port);
+
+        using var ws = await server.CreateWebSocketClient()
+            .ConnectAsync(new Uri("ws://localhost/api/proxy?mode=tcp"), CancellationToken.None);
+
+        var payload = CreatePayload(payloadBytes);
+        await ws.SendAsync(payload, WebSocketMessageType.Binary, true, CancellationToken.None);
+        var echoed = await ReceiveAtLeastBytesAsync(ws, payload.Length, CancellationToken.None);
+
+        Assert.Equal(payload.Length, echoed.Length);
+        Assert.Equal(payload, echoed);
+
+        var observed = await WaitForTrafficAsync(flow, payload.Length, TimeSpan.FromSeconds(3));
+        Assert.NotNull(observed);
+        Assert.True(observed!.ClientToServerBytesTotal >= payload.Length);
+        Assert.True(observed.ServerToClientBytesTotal >= payload.Length);
+
+        await TryCloseAsync(ws);
+        await WaitUntilAsync(() => active.Count == 0, TimeSpan.FromSeconds(2));
+    }
+
+    [Fact]
+    public async Task TcpProxy_Handles1000ConcurrentClients()
+    {
+        const int clientsCount = 1_000;
+        const int payloadSize = 512;
+
+        await using var echo = await TcpEchoServer.StartAsync();
+        var (server, _, flow) = CreateProxyTestServer(echo.Port);
+
+        var tasks = Enumerable.Range(0, clientsCount)
+            .Select(async i =>
+            {
+                using var ws = await server.CreateWebSocketClient()
+                    .ConnectAsync(new Uri("ws://localhost/api/proxy?mode=tcp"), CancellationToken.None);
+
+                var payload = CreatePayload(payloadSize + i);
+                await ws.SendAsync(payload, WebSocketMessageType.Binary, true, CancellationToken.None);
+                var echoed = await ReceiveAtLeastBytesAsync(ws, payload.Length, CancellationToken.None);
+                Assert.Equal(payload, echoed);
+                await TryCloseAsync(ws);
+            })
+            .ToArray();
+
+        await Task.WhenAll(tasks);
+
+        // Verify flow service observed traffic from many independent connections.
+        var batch = flow.BuildBatch(DateTime.UtcNow);
+        Assert.True(batch.Count >= clientsCount);
+    }
+
+    private static (TestServer Server, ActiveProxyConnectionService Active, ProxyTrafficFlowService Flow) CreateProxyTestServer(int tcpTargetPort)
+    {
+        var active = new ActiveProxyConnectionService();
+        var history = new ProxyConnectionHistoryService();
+        var flow = new ProxyTrafficFlowService();
+        var identityResolver = new ProxyConnectionIdentityResolver();
+
+        var hostBuilder = new WebHostBuilder()
+            .ConfigureAppConfiguration((_, cfg) =>
+            {
+                cfg.AddInMemoryCollection(new Dictionary<string, string?>
+                {
+                    ["PORT"] = tcpTargetPort.ToString()
+                });
+            })
+            .ConfigureServices(services =>
+            {
+                services.AddSingleton<IActiveProxyConnectionService>(active);
+                services.AddSingleton<IProxyConnectionHistoryService>(history);
+                services.AddSingleton<IProxyTrafficFlowService>(flow);
+                services.AddSingleton<IProxyConnectionIdentityResolver>(identityResolver);
+                services.AddSingleton(NullLogger<OpenVpnProxyController>.Instance);
+                services.AddControllers().AddApplicationPart(typeof(OpenVpnProxyController).Assembly);
+            })
+            .Configure(app =>
+            {
+                app.UseWebSockets();
+                app.UseRouting();
+                app.UseEndpoints(endpoints => endpoints.MapControllers());
+            });
+
+        return (new TestServer(hostBuilder), active, flow);
+    }
+
+    private static byte[] CreatePayload(int size)
+    {
+        var bytes = new byte[size];
+        for (var i = 0; i < bytes.Length; i += 1)
+            bytes[i] = (byte)(i % 251);
+        return bytes;
+    }
+
+    private static async Task<byte[]> ReceiveAtLeastBytesAsync(WebSocket ws, int expectedBytes, CancellationToken ct)
+    {
+        var buffer = new byte[16 * 1024];
+        using var ms = new MemoryStream();
+        while (ms.Length < expectedBytes)
+        {
+            var res = await ws.ReceiveAsync(buffer, ct);
+            if (res.MessageType == WebSocketMessageType.Close)
+                throw new InvalidOperationException("WebSocket closed before payload was received.");
+            if (res.MessageType != WebSocketMessageType.Binary)
+                continue;
+
+            if (res.Count > 0)
+                ms.Write(buffer, 0, res.Count);
+        }
+
+        return ms.ToArray();
+    }
+
+    private static async Task TryCloseAsync(WebSocket ws)
+    {
+        try
+        {
+            if (ws.State == WebSocketState.Open || ws.State == WebSocketState.CloseReceived)
+                await ws.CloseAsync(WebSocketCloseStatus.NormalClosure, "done", CancellationToken.None);
+        }
+        catch
+        {
+            // remote may already close during pump teardown under load
+        }
+    }
+
+    private static async Task<ProxyTrafficFlowUpdate?> WaitForTrafficAsync(
+        ProxyTrafficFlowService flow,
+        int atLeastBytes,
+        TimeSpan timeout)
+    {
+        var started = DateTime.UtcNow;
+        while (DateTime.UtcNow - started < timeout)
+        {
+            var batch = flow.BuildBatch(DateTime.UtcNow);
+            var hit = batch.FirstOrDefault(x =>
+                x.ClientToServerBytesTotal >= atLeastBytes &&
+                x.ServerToClientBytesTotal >= atLeastBytes);
+            if (hit is not null)
+                return hit;
+
+            await Task.Delay(25);
+        }
+
+        return null;
+    }
+
+    private static async Task WaitUntilAsync(Func<bool> condition, TimeSpan timeout)
+    {
+        var started = DateTime.UtcNow;
+        while (DateTime.UtcNow - started < timeout)
+        {
+            if (condition()) return;
+            await Task.Delay(25);
+        }
+
+        Assert.True(condition(), "Condition was not met before timeout.");
+    }
+
+    private sealed class TcpEchoServer : IAsyncDisposable
+    {
+        private readonly TcpListener _listener;
+        private readonly CancellationTokenSource _cts = new();
+        private readonly Task _acceptLoopTask;
+        private readonly List<Task> _clientTasks = [];
+
+        public int Port { get; }
+
+        private TcpEchoServer(TcpListener listener)
+        {
+            _listener = listener;
+            Port = ((System.Net.IPEndPoint)listener.LocalEndpoint).Port;
+            _acceptLoopTask = AcceptLoopAsync();
+        }
+
+        public static Task<TcpEchoServer> StartAsync()
+        {
+            var listener = new TcpListener(System.Net.IPAddress.Loopback, 0);
+            listener.Start();
+            return Task.FromResult(new TcpEchoServer(listener));
+        }
+
+        private async Task AcceptLoopAsync()
+        {
+            try
+            {
+                while (!_cts.IsCancellationRequested)
+                {
+                    var client = await _listener.AcceptTcpClientAsync(_cts.Token);
+                    var task = HandleClientAsync(client, _cts.Token);
+                    lock (_clientTasks) _clientTasks.Add(task);
+                }
+            }
+            catch (OperationCanceledException)
+            {
+                // expected on shutdown
+            }
+            catch (ObjectDisposedException)
+            {
+                // expected on shutdown
+            }
+        }
+
+        private static async Task HandleClientAsync(TcpClient client, CancellationToken ct)
+        {
+            using (client)
+            await using (var stream = client.GetStream())
+            {
+                var buffer = new byte[16 * 1024];
+                while (!ct.IsCancellationRequested)
+                {
+                    var read = await stream.ReadAsync(buffer, ct);
+                    if (read <= 0) break;
+                    await stream.WriteAsync(buffer.AsMemory(0, read), ct);
+                }
+            }
+        }
+
+        public async ValueTask DisposeAsync()
+        {
+            _cts.Cancel();
+            _listener.Stop();
+            try { await _acceptLoopTask; } catch { /* ignored */ }
+            Task[] tasks;
+            lock (_clientTasks) tasks = _clientTasks.ToArray();
+            try { await Task.WhenAll(tasks); } catch { /* ignored */ }
+            _cts.Dispose();
+        }
+    }
+}

--- a/DataGateOpenVpnManager.Tests/Controllers/OpenVpnProxyControllerTests.cs
+++ b/DataGateOpenVpnManager.Tests/Controllers/OpenVpnProxyControllerTests.cs
@@ -15,12 +15,16 @@ public class OpenVpnProxyControllerTests
 {
     private static OpenVpnProxyController CreateController(
         IActiveProxyConnectionService active,
-        IProxyConnectionHistoryService? history = null)
+        IProxyConnectionHistoryService? history = null,
+        IProxyTrafficFlowService? trafficFlow = null,
+        IProxyConnectionIdentityResolver? identityResolver = null)
     {
         var config = new ConfigurationBuilder().AddInMemoryCollection().Build();
         var logger = new Mock<ILogger<OpenVpnProxyController>>();
         history ??= new Mock<IProxyConnectionHistoryService>().Object;
-        return new OpenVpnProxyController(config, logger.Object, active, history);
+        trafficFlow ??= new Mock<IProxyTrafficFlowService>().Object;
+        identityResolver ??= new Mock<IProxyConnectionIdentityResolver>().Object;
+        return new OpenVpnProxyController(config, logger.Object, active, history, trafficFlow, identityResolver);
     }
 
     [Fact]

--- a/DataGateOpenVpnManager.Tests/DataGateOpenVpnManager.Tests.csproj
+++ b/DataGateOpenVpnManager.Tests/DataGateOpenVpnManager.Tests.csproj
@@ -13,6 +13,7 @@
           <PrivateAssets>all</PrivateAssets>
           <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
         </PackageReference>
+        <PackageReference Include="Microsoft.AspNetCore.TestHost" Version="10.0.8" />
         <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.3.0" />
         <PackageReference Include="Moq" Version="4.20.72" />
         <!-- DataGateMonitor.SharedModels: NuGet package only; do not use ProjectReference to the SharedModels .csproj. -->
@@ -25,7 +26,7 @@
     </ItemGroup>
 
     <ItemGroup>
-        <Using Include="Xunit"/>
+        <Using Include="Xunit" />
     </ItemGroup>
 
     <ItemGroup>

--- a/DataGateOpenVpnManager.Tests/Hubs/ProxyTrafficFlowHubTests.cs
+++ b/DataGateOpenVpnManager.Tests/Hubs/ProxyTrafficFlowHubTests.cs
@@ -1,0 +1,14 @@
+using DataGateOpenVpnManager.Hubs;
+using Microsoft.Extensions.Logging.Abstractions;
+
+namespace DataGateOpenVpnManager.Tests.Hubs;
+
+public class ProxyTrafficFlowHubTests
+{
+    [Fact]
+    public void Hub_CanBeConstructed_WithLogger()
+    {
+        var hub = new ProxyTrafficFlowHub(new NullLogger<ProxyTrafficFlowHub>());
+        Assert.NotNull(hub);
+    }
+}

--- a/DataGateOpenVpnManager.Tests/Middlewares/JwtValidationMiddlewareTests.cs
+++ b/DataGateOpenVpnManager.Tests/Middlewares/JwtValidationMiddlewareTests.cs
@@ -55,6 +55,23 @@ public class JwtValidationMiddlewareTests
         Assert.True(nextCalled);
     }
 
+    [Fact]
+    public async Task Invoke_WhenPathIsExcludedAndBearerTokenValid_AttachesPrincipal()
+    {
+        var nextCalled = false;
+        RequestDelegate next = _ => { nextCalled = true; return Task.CompletedTask; };
+        ClaimsPrincipal? principal = new ClaimsPrincipal(new ClaimsIdentity("Test"));
+        var validatorMock = new Mock<IMicroserviceJwtValidator>();
+        validatorMock.Setup(v => v.ValidateToken("valid-token", out principal)).Returns(true);
+        var middleware = new JwtValidationMiddleware(next);
+
+        var context = CreateContext("/api/proxy", authHeader: "Bearer valid-token");
+        await middleware.Invoke(context, validatorMock.Object);
+
+        Assert.True(nextCalled);
+        Assert.Equal(principal, context.User);
+    }
+
     [Theory]
     [InlineData("/api/vpn-events/connect")]
     [InlineData("/api/vpn-events/disconnect")]

--- a/DataGateOpenVpnManager.Tests/Services/Proxy/ProxyConnectionIdentityResolverTests.cs
+++ b/DataGateOpenVpnManager.Tests/Services/Proxy/ProxyConnectionIdentityResolverTests.cs
@@ -1,0 +1,89 @@
+using System.Security.Claims;
+using DataGateOpenVpnManager.Services.Proxy;
+using Microsoft.AspNetCore.Http;
+
+namespace DataGateOpenVpnManager.Tests.Services.Proxy;
+
+public class ProxyConnectionIdentityResolverTests
+{
+    [Fact]
+    public void Resolve_ReturnsNull_WhenNoIdentityData()
+    {
+        var resolver = new ProxyConnectionIdentityResolver();
+        var context = new DefaultHttpContext();
+
+        var result = resolver.Resolve(context, null);
+
+        Assert.Null(result);
+    }
+
+    [Fact]
+    public void Resolve_UsesClientRefFromQuery_WhenProvided()
+    {
+        var resolver = new ProxyConnectionIdentityResolver();
+        var context = new DefaultHttpContext();
+
+        var result = resolver.Resolve(context, " app-client-1 ");
+
+        Assert.NotNull(result);
+        Assert.Equal("app-client-1", result!.ClientRef);
+    }
+
+    [Fact]
+    public void Resolve_UsesClientRefFromHeader_WhenQueryMissing()
+    {
+        var resolver = new ProxyConnectionIdentityResolver();
+        var context = new DefaultHttpContext();
+        context.Request.Headers["X-Client-Ref"] = "hdr-client";
+
+        var result = resolver.Resolve(context, null);
+
+        Assert.NotNull(result);
+        Assert.Equal("hdr-client", result!.ClientRef);
+    }
+
+    [Fact]
+    public void Resolve_PrefersPrimaryClaims_InConfiguredOrder()
+    {
+        var resolver = new ProxyConnectionIdentityResolver();
+        var context = new DefaultHttpContext();
+        var claims = new[]
+        {
+            new Claim("sub", "42"),
+            new Claim(ClaimTypes.NameIdentifier, "1001"),
+            new Claim("preferred_username", "preferred"),
+            new Claim(ClaimTypes.Name, "primary-name"),
+            new Claim("email", "user@example.com")
+        };
+        context.User = new ClaimsPrincipal(new ClaimsIdentity(claims, "Test"));
+
+        var result = resolver.Resolve(context, null);
+
+        Assert.NotNull(result);
+        Assert.Equal("1001", result!.UserId);
+        Assert.Equal("primary-name", result.Username);
+        Assert.Equal("user@example.com", result.Email);
+    }
+
+    [Fact]
+    public void Resolve_TrimsWhitespace_FromAllIdentityFields()
+    {
+        var resolver = new ProxyConnectionIdentityResolver();
+        var context = new DefaultHttpContext();
+        var claims = new[]
+        {
+            new Claim("uid", "  777 "),
+            new Claim("username", "  john  "),
+            new Claim(ClaimTypes.Email, "  john@example.com  ")
+        };
+        context.User = new ClaimsPrincipal(new ClaimsIdentity(claims, "Test"));
+
+        var result = resolver.Resolve(context, "  mobile-app  ");
+
+        Assert.NotNull(result);
+        Assert.Equal("mobile-app", result!.ClientRef);
+        Assert.Equal("777", result.UserId);
+        Assert.Equal("john", result.Username);
+        Assert.Equal("john@example.com", result.Email);
+    }
+}

--- a/DataGateOpenVpnManager.Tests/Services/Proxy/ProxyTrafficFlowServiceTests.cs
+++ b/DataGateOpenVpnManager.Tests/Services/Proxy/ProxyTrafficFlowServiceTests.cs
@@ -1,0 +1,131 @@
+using DataGateOpenVpnManager.Services.Proxy;
+using DataGateMonitor.SharedModels.DataGateOpenVpnManager.Proxy;
+using DataGateMonitor.SharedModels.DataGateOpenVpnManager.Proxy.Enums;
+
+namespace DataGateOpenVpnManager.Tests.Services.Proxy;
+
+public class ProxyTrafficFlowServiceTests
+{
+    [Fact]
+    public void BuildBatch_ReportsIdleConnection_WhenNoTrafficForThreshold()
+    {
+        var service = new ProxyTrafficFlowService();
+        var connectedAt = new DateTime(2026, 05, 08, 12, 0, 0, DateTimeKind.Utc);
+        service.RegisterConnection(new ActiveProxyConnection
+        {
+            ConnectionId = "conn-1",
+            Protocol = ProxyConnectionProtocol.Tcp,
+            RealClientIp = "198.51.100.10",
+            RealClientPort = 50000,
+            LocalProxyIp = "127.0.0.1",
+            LocalProxyPort = 60000,
+            TargetIp = "127.0.0.1",
+            TargetPort = 1194,
+            ConnectedAtUtc = connectedAt
+        });
+
+        var batch = service.BuildBatch(connectedAt.AddSeconds(11));
+        var update = Assert.Single(batch);
+        Assert.Equal("conn-1", update.ConnectionId);
+        Assert.True(update.IsConnected);
+        Assert.True(update.IsIdle);
+        Assert.Equal(0, update.ClientToServerBytesDelta);
+        Assert.Equal(0, update.ServerToClientBytesDelta);
+    }
+
+    [Fact]
+    public void BuildBatch_ResetsDeltas_AfterEmission()
+    {
+        var service = new ProxyTrafficFlowService();
+        var connectedAt = new DateTime(2026, 05, 08, 12, 0, 0, DateTimeKind.Utc);
+        service.RegisterConnection(new ActiveProxyConnection
+        {
+            ConnectionId = "conn-2",
+            Protocol = ProxyConnectionProtocol.Udp,
+            RealClientIp = "203.0.113.7",
+            RealClientPort = 51000,
+            LocalProxyIp = "127.0.0.1",
+            LocalProxyPort = 60100,
+            TargetIp = "127.0.0.1",
+            TargetPort = 1194,
+            ConnectedAtUtc = connectedAt
+        });
+
+        service.RecordTraffic("conn-2", ProxyTrafficFlowDirection.ClientToServer, 1200, connectedAt.AddSeconds(1));
+        service.RecordTraffic("conn-2", ProxyTrafficFlowDirection.ServerToClient, 800, connectedAt.AddSeconds(2));
+
+        var firstBatch = service.BuildBatch(connectedAt.AddSeconds(3));
+        var first = Assert.Single(firstBatch);
+        Assert.Equal(1200, first.ClientToServerBytesDelta);
+        Assert.Equal(800, first.ServerToClientBytesDelta);
+        Assert.False(first.IsIdle);
+
+        var secondBatch = service.BuildBatch(connectedAt.AddSeconds(4));
+        var second = Assert.Single(secondBatch);
+        Assert.Equal(0, second.ClientToServerBytesDelta);
+        Assert.Equal(0, second.ServerToClientBytesDelta);
+        Assert.Equal(1200, second.ClientToServerBytesTotal);
+        Assert.Equal(800, second.ServerToClientBytesTotal);
+    }
+
+    [Fact]
+    public void UnregisterConnection_EmitsDisconnectedUpdate()
+    {
+        var service = new ProxyTrafficFlowService();
+        var connectedAt = new DateTime(2026, 05, 08, 12, 0, 0, DateTimeKind.Utc);
+        var disconnectedAt = connectedAt.AddSeconds(5);
+        service.RegisterConnection(new ActiveProxyConnection
+        {
+            ConnectionId = "conn-3",
+            Protocol = ProxyConnectionProtocol.Tcp,
+            RealClientIp = "192.0.2.22",
+            RealClientPort = 52000,
+            LocalProxyIp = "127.0.0.1",
+            LocalProxyPort = 60200,
+            TargetIp = "127.0.0.1",
+            TargetPort = 1194,
+            ConnectedAtUtc = connectedAt
+        });
+
+        service.RecordTraffic("conn-3", ProxyTrafficFlowDirection.ClientToServer, 512, connectedAt.AddSeconds(2));
+        service.UnregisterConnection("conn-3", disconnectedAt);
+
+        var batch = service.BuildBatch(disconnectedAt);
+        var update = Assert.Single(batch);
+        Assert.Equal("disconnected", update.State);
+        Assert.False(update.IsConnected);
+        Assert.Equal(512, update.ClientToServerBytesTotal);
+    }
+
+    [Fact]
+    public void BuildBatch_IncludesIdentityMetadata_WhenProvided()
+    {
+        var service = new ProxyTrafficFlowService();
+        var connectedAt = new DateTime(2026, 05, 08, 12, 0, 0, DateTimeKind.Utc);
+        service.RegisterConnection(new ActiveProxyConnection
+        {
+            ConnectionId = "conn-4",
+            Protocol = ProxyConnectionProtocol.Tcp,
+            RealClientIp = "198.18.0.9",
+            RealClientPort = 53000,
+            LocalProxyIp = "127.0.0.1",
+            LocalProxyPort = 60300,
+            TargetIp = "127.0.0.1",
+            TargetPort = 1194,
+            ConnectedAtUtc = connectedAt
+        }, new ProxyConnectionIdentity
+        {
+            ClientRef = "client-app-42",
+            UserId = "1001",
+            Username = "alice",
+            Email = "alice@example.com"
+        });
+
+        var batch = service.BuildBatch(connectedAt.AddSeconds(1));
+        var update = Assert.Single(batch);
+        Assert.Equal("client-app-42", update.ClientRef);
+        Assert.Equal("1001", update.UserId);
+        Assert.Equal("alice", update.Username);
+        Assert.Equal("alice@example.com", update.Email);
+    }
+}

--- a/DataGateOpenVpnManager.Tests/Services/Proxy/ProxyTrafficFlowServiceTests.cs
+++ b/DataGateOpenVpnManager.Tests/Services/Proxy/ProxyTrafficFlowServiceTests.cs
@@ -6,6 +6,115 @@ namespace DataGateOpenVpnManager.Tests.Services.Proxy;
 
 public class ProxyTrafficFlowServiceTests
 {
+    [Theory]
+    [InlineData(1_000)]
+    [InlineData(10_000)]
+    public void BuildBatch_WithLargeOnlinePopulation_HandlesThousandAndTenThousandUsers(int usersCount)
+    {
+        var service = new ProxyTrafficFlowService();
+        var connectedAt = new DateTime(2026, 05, 08, 12, 0, 0, DateTimeKind.Utc);
+
+        for (var i = 0; i < usersCount; i += 1)
+        {
+            service.RegisterConnection(new ActiveProxyConnection
+            {
+                ConnectionId = $"u-{i}",
+                Protocol = ProxyConnectionProtocol.Tcp,
+                RealClientIp = $"198.51.{(i / 256) % 256}.{i % 256}",
+                RealClientPort = 30000 + (i % 20000),
+                LocalProxyIp = "127.0.0.1",
+                LocalProxyPort = 40000 + (i % 20000),
+                TargetIp = "127.0.0.1",
+                TargetPort = 1194,
+                ConnectedAtUtc = connectedAt
+            });
+        }
+
+        Parallel.For(0, usersCount, i =>
+        {
+            var cid = $"u-{i}";
+            service.RecordTraffic(cid, ProxyTrafficFlowDirection.ClientToServer, 64, connectedAt.AddSeconds(1));
+            service.RecordTraffic(cid, ProxyTrafficFlowDirection.ServerToClient, 128, connectedAt.AddSeconds(1));
+        });
+
+        var batch = service.BuildBatch(connectedAt.AddSeconds(2));
+        Assert.Equal(usersCount, batch.Count);
+        Assert.All(batch, item =>
+        {
+            Assert.True(item.IsConnected);
+            Assert.Equal("connected", item.State);
+            Assert.Equal(64, item.ClientToServerBytesDelta);
+            Assert.Equal(128, item.ServerToClientBytesDelta);
+            Assert.Equal(64, item.ClientToServerBytesTotal);
+            Assert.Equal(128, item.ServerToClientBytesTotal);
+        });
+    }
+
+    [Fact]
+    public async Task BuildBatch_With25ConcurrentConnections_PreservesTotalsAndDeltas()
+    {
+        const int connectionsCount = 25;
+        const int iterationsPerConnection = 400;
+        const int c2sBytes = 37;
+        const int s2cBytes = 53;
+
+        var service = new ProxyTrafficFlowService();
+        var connectedAt = new DateTime(2026, 05, 08, 12, 0, 0, DateTimeKind.Utc);
+
+        for (var i = 0; i < connectionsCount; i += 1)
+        {
+            service.RegisterConnection(new ActiveProxyConnection
+            {
+                ConnectionId = $"conn-{i}",
+                Protocol = ProxyConnectionProtocol.Tcp,
+                RealClientIp = $"198.51.100.{i + 1}",
+                RealClientPort = 50000 + i,
+                LocalProxyIp = "127.0.0.1",
+                LocalProxyPort = 60000 + i,
+                TargetIp = "127.0.0.1",
+                TargetPort = 1194,
+                ConnectedAtUtc = connectedAt
+            });
+        }
+
+        var tasks = Enumerable.Range(0, connectionsCount)
+            .Select(i => Task.Run(() =>
+            {
+                var connectionId = $"conn-{i}";
+                for (var n = 0; n < iterationsPerConnection; n += 1)
+                {
+                    service.RecordTraffic(connectionId, ProxyTrafficFlowDirection.ClientToServer, c2sBytes, connectedAt.AddSeconds(1));
+                    service.RecordTraffic(connectionId, ProxyTrafficFlowDirection.ServerToClient, s2cBytes, connectedAt.AddSeconds(1));
+                }
+            }))
+            .ToArray();
+
+        await Task.WhenAll(tasks);
+
+        var batch = service.BuildBatch(connectedAt.AddSeconds(2));
+        Assert.Equal(connectionsCount, batch.Count);
+
+        var expectedC2S = (long)iterationsPerConnection * c2sBytes;
+        var expectedS2C = (long)iterationsPerConnection * s2cBytes;
+        foreach (var update in batch)
+        {
+            Assert.True(update.IsConnected);
+            Assert.Equal("connected", update.State);
+            Assert.Equal(expectedC2S, update.ClientToServerBytesTotal);
+            Assert.Equal(expectedS2C, update.ServerToClientBytesTotal);
+            Assert.Equal(expectedC2S, update.ClientToServerBytesDelta);
+            Assert.Equal(expectedS2C, update.ServerToClientBytesDelta);
+        }
+
+        var secondBatch = service.BuildBatch(connectedAt.AddSeconds(3));
+        Assert.Equal(connectionsCount, secondBatch.Count);
+        foreach (var update in secondBatch)
+        {
+            Assert.Equal(0, update.ClientToServerBytesDelta);
+            Assert.Equal(0, update.ServerToClientBytesDelta);
+        }
+    }
+
     [Fact]
     public void BuildBatch_ReportsIdleConnection_WhenNoTrafficForThreshold()
     {

--- a/DataGateOpenVpnManager/Configurations/PipelineConfiguration.cs
+++ b/DataGateOpenVpnManager/Configurations/PipelineConfiguration.cs
@@ -45,5 +45,6 @@ public static class PipelineConfiguration
         //SignalR
         app.MapHub<OpenVpnSignalHub>("/hubs/openvpn");
         app.MapHub<OpenVpnEventHub>("/hubs/openvpn-event");
+        app.MapHub<ProxyTrafficFlowHub>("/hubs/proxy-traffic-flow");
     }
 }

--- a/DataGateOpenVpnManager/Configurations/ProxyConfiguration.cs
+++ b/DataGateOpenVpnManager/Configurations/ProxyConfiguration.cs
@@ -8,5 +8,8 @@ public static class ProxyConfiguration
     {
         services.AddSingleton<IProxyConnectionHistoryService, ProxyConnectionHistoryService>();
         services.AddSingleton<IActiveProxyConnectionService, ActiveProxyConnectionService>();
+        services.AddSingleton<IProxyConnectionIdentityResolver, ProxyConnectionIdentityResolver>();
+        services.AddSingleton<IProxyTrafficFlowService, ProxyTrafficFlowService>();
+        services.AddHostedService<ProxyTrafficFlowBroadcastService>();
     }
 }

--- a/DataGateOpenVpnManager/Controllers/OpenVpnProxyController.cs
+++ b/DataGateOpenVpnManager/Controllers/OpenVpnProxyController.cs
@@ -16,7 +16,9 @@ public class OpenVpnProxyController(
     IConfiguration config,
     ILogger<OpenVpnProxyController> logger,
     IActiveProxyConnectionService activeProxyConnections,
-    IProxyConnectionHistoryService proxyConnectionHistory) : ControllerBase
+    IProxyConnectionHistoryService proxyConnectionHistory,
+    IProxyTrafficFlowService proxyTrafficFlow,
+    IProxyConnectionIdentityResolver identityResolver) : ControllerBase
 {
     private const int MaxUdpDatagramSize = 64 * 1024;
     private const int WsSegmentSize = 16 * 1024;
@@ -56,7 +58,7 @@ public class OpenVpnProxyController(
         };
 
     [HttpGet]
-    public async Task Get([FromQuery] string? mode = null)
+    public async Task Get([FromQuery] string? mode = null, [FromQuery] string? clientRef = null)
     {
         if (!HttpContext.WebSockets.IsWebSocketRequest)
         {
@@ -82,14 +84,15 @@ public class OpenVpnProxyController(
         using var linkedCts = CancellationTokenSource.CreateLinkedTokenSource(ct);
 
         var modeNorm = (mode ?? "tcp").Trim().ToLowerInvariant();
+        var identity = identityResolver.Resolve(HttpContext, clientRef);
         var connectionId = Guid.NewGuid().ToString("N");
 
         try
         {
             if (modeNorm == "udp")
-                await HandleUdp(ws, targetIp, vpnPort, linkedCts.Token, logger, connectionId);
+                await HandleUdp(ws, targetIp, vpnPort, linkedCts.Token, logger, connectionId, identity);
             else
-                await HandleTcp(ws, targetHost, vpnPort, linkedCts.Token, logger, connectionId);
+                await HandleTcp(ws, targetHost, vpnPort, linkedCts.Token, logger, connectionId, identity);
         }
         catch (OperationCanceledException)
         {
@@ -117,7 +120,8 @@ public class OpenVpnProxyController(
         int vpnPort,
         CancellationToken ct,
         ILogger logger,
-        string connectionId)
+        string connectionId,
+        ProxyConnectionIdentity? identity)
     {
         using var tcp = new TcpClient();
         tcp.NoDelay = true;
@@ -129,21 +133,21 @@ public class OpenVpnProxyController(
         catch (Exception e)
         {
             logger.LogError(e, "TCP connect failed. {Host}:{Port}. {Message}", targetHost, vpnPort, e.Message);
-            RecordConnectFailed(connectionId, ProxyConnectionProtocol.Tcp, targetHost, vpnPort, e.Message);
+            RecordConnectFailed(connectionId, ProxyConnectionProtocol.Tcp, targetHost, vpnPort, e.Message, identity);
             await TryCloseWs(ws, "TCP connect failed", logger);
             return;
         }
 
         var localEp = (IPEndPoint)tcp.Client.LocalEndPoint!;
         var remoteEp = (IPEndPoint)tcp.Client.RemoteEndPoint!;
-        RegisterActiveConnection(connectionId, ProxyConnectionProtocol.Tcp, localEp, remoteEp);
+        RegisterActiveConnection(connectionId, ProxyConnectionProtocol.Tcp, localEp, remoteEp, identity);
 
         try
         {
             await using var tcpStream = tcp.GetStream();
 
-            var wsToTcp = PumpWebSocketToTcp(ws, tcpStream, ct, logger);
-            var tcpToWs = PumpTcpToWebSocket(ws, tcpStream, ct, logger);
+            var wsToTcp = PumpWebSocketToTcp(ws, tcpStream, ct, logger, connectionId, proxyTrafficFlow);
+            var tcpToWs = PumpTcpToWebSocket(ws, tcpStream, ct, logger, connectionId, proxyTrafficFlow);
 
             await Task.WhenAny(wsToTcp, tcpToWs);
         }
@@ -159,7 +163,8 @@ public class OpenVpnProxyController(
         int vpnPort,
         CancellationToken ct,
         ILogger logger,
-        string connectionId)
+        string connectionId,
+        ProxyConnectionIdentity? identity)
     {
         var remote = new IPEndPoint(targetIp, vpnPort);
 
@@ -172,14 +177,14 @@ public class OpenVpnProxyController(
         catch (Exception e)
         {
             logger.LogError(e, "UDP connect failed. {Host}:{Port}. {Message}", remote.Address, remote.Port, e.Message);
-            RecordConnectFailed(connectionId, ProxyConnectionProtocol.Udp, remote.Address.ToString(), remote.Port, e.Message);
+            RecordConnectFailed(connectionId, ProxyConnectionProtocol.Udp, remote.Address.ToString(), remote.Port, e.Message, identity);
             if (ws.State == WebSocketState.Open)
                 await SafeCloseWs(ws, WebSocketCloseStatus.InternalServerError, "UDP connect failed");
             return;
         }
 
         var localEp = (IPEndPoint)udp.Client.LocalEndPoint!;
-        RegisterActiveConnection(connectionId, ProxyConnectionProtocol.Udp, localEp, remote);
+        RegisterActiveConnection(connectionId, ProxyConnectionProtocol.Udp, localEp, remote, identity);
 
         // Optional: read and ignore app-level "connect" JSON message (text)
         // Your C++ bridge sends it right after handshake.
@@ -224,6 +229,7 @@ public class OpenVpnProxyController(
                             }
 
                             await udp.SendAsync(data.AsMemory(off, len), ct);
+                            proxyTrafficFlow.RecordTraffic(connectionId, ProxyTrafficFlowDirection.ClientToServer, len);
                             off += len;
                         }
                     }
@@ -261,6 +267,7 @@ public class OpenVpnProxyController(
                             WebSocketMessageType.Binary,
                             endOfMessage: true,
                             cancellationToken: ct);
+                        proxyTrafficFlow.RecordTraffic(connectionId, ProxyTrafficFlowDirection.ServerToClient, pkt.Buffer.Length);
                     }
                 }
                 catch (OperationCanceledException)
@@ -291,7 +298,8 @@ public class OpenVpnProxyController(
         string connectionId,
         ProxyConnectionProtocol protocol,
         IPEndPoint localEp,
-        IPEndPoint remoteTargetEp)
+        IPEndPoint remoteTargetEp,
+        ProxyConnectionIdentity? identity)
     {
         var (clientIp, clientPort) = GetHttpClientAddress();
         var connection = new ActiveProxyConnection
@@ -308,6 +316,7 @@ public class OpenVpnProxyController(
         };
 
         activeProxyConnections.Add(connection);
+        proxyTrafficFlow.RegisterConnection(connection, identity);
 
         proxyConnectionHistory.Add(new ProxyConnectionHistoryItem
         {
@@ -329,10 +338,12 @@ public class OpenVpnProxyController(
         if (!activeProxyConnections.TryGet(connectionId, out var conn) || conn is null)
         {
             activeProxyConnections.Remove(connectionId);
+            proxyTrafficFlow.UnregisterConnection(connectionId);
             return;
         }
 
         activeProxyConnections.Remove(connectionId);
+        proxyTrafficFlow.UnregisterConnection(connectionId);
 
         proxyConnectionHistory.Add(new ProxyConnectionHistoryItem
         {
@@ -354,9 +365,11 @@ public class OpenVpnProxyController(
         ProxyConnectionProtocol protocol,
         string targetIp,
         int targetPort,
-        string errorMessage)
+        string errorMessage,
+        ProxyConnectionIdentity? identity)
     {
         var (clientIp, clientPort) = GetHttpClientAddress();
+        proxyTrafficFlow.RegisterConnectFailed(connectionId, protocol, clientIp, clientPort, identity, targetIp, targetPort, errorMessage);
         proxyConnectionHistory.Add(new ProxyConnectionHistoryItem
         {
             ConnectionId = connectionId,
@@ -481,7 +494,9 @@ public class OpenVpnProxyController(
         WebSocket ws,
         NetworkStream tcp,
         CancellationToken ct,
-        ILogger logger)
+        ILogger logger,
+        string connectionId,
+        IProxyTrafficFlowService proxyTrafficFlow)
     {
         var buffer = new byte[16 * 1024];
 
@@ -498,6 +513,7 @@ public class OpenVpnProxyController(
                     continue;
 
                 await tcp.WriteAsync(buffer.AsMemory(0, result.Count), ct);
+                proxyTrafficFlow.RecordTraffic(connectionId, ProxyTrafficFlowDirection.ClientToServer, result.Count);
 
                 while (!result.EndOfMessage)
                 {
@@ -506,6 +522,7 @@ public class OpenVpnProxyController(
                         break;
 
                     await tcp.WriteAsync(buffer.AsMemory(0, result.Count), ct);
+                    proxyTrafficFlow.RecordTraffic(connectionId, ProxyTrafficFlowDirection.ClientToServer, result.Count);
                 }
 
                 // NetworkStream flush is typically unnecessary and may hurt throughput/latency.
@@ -526,7 +543,9 @@ public class OpenVpnProxyController(
         WebSocket ws,
         NetworkStream tcp,
         CancellationToken ct,
-        ILogger logger)
+        ILogger logger,
+        string connectionId,
+        IProxyTrafficFlowService proxyTrafficFlow)
     {
         var buffer = new byte[16 * 1024];
 
@@ -544,6 +563,7 @@ public class OpenVpnProxyController(
                     endOfMessage: true,
                     cancellationToken: ct
                 );
+                proxyTrafficFlow.RecordTraffic(connectionId, ProxyTrafficFlowDirection.ServerToClient, read);
             }
         }
         catch (OperationCanceledException ex)

--- a/DataGateOpenVpnManager/Controllers/OpenVpnProxyController.cs
+++ b/DataGateOpenVpnManager/Controllers/OpenVpnProxyController.cs
@@ -145,11 +145,15 @@ public class OpenVpnProxyController(
         try
         {
             await using var tcpStream = tcp.GetStream();
+            using var pumpCts = CancellationTokenSource.CreateLinkedTokenSource(ct);
+            var pumpCt = pumpCts.Token;
 
-            var wsToTcp = PumpWebSocketToTcp(ws, tcpStream, ct, logger, connectionId, proxyTrafficFlow);
-            var tcpToWs = PumpTcpToWebSocket(ws, tcpStream, ct, logger, connectionId, proxyTrafficFlow);
+            var wsToTcp = PumpWebSocketToTcp(ws, tcpStream, pumpCt, logger, connectionId, proxyTrafficFlow);
+            var tcpToWs = PumpTcpToWebSocket(ws, tcpStream, pumpCt, logger, connectionId, proxyTrafficFlow);
 
             await Task.WhenAny(wsToTcp, tcpToWs);
+            // One direction finished: stop the sibling pump quickly to avoid lingering under load.
+            pumpCts.Cancel();
         }
         finally
         {
@@ -186,10 +190,6 @@ public class OpenVpnProxyController(
         var localEp = (IPEndPoint)udp.Client.LocalEndPoint!;
         RegisterActiveConnection(connectionId, ProxyConnectionProtocol.Udp, localEp, remote, identity);
 
-        // Optional: read and ignore app-level "connect" JSON message (text)
-        // Your C++ bridge sends it right after handshake.
-        await TryDrainOptionalConnectMessage(ws, ct, logger);
-
         try
         {
             var wsToUdp = Task.Run(async () =>
@@ -199,7 +199,7 @@ public class OpenVpnProxyController(
                     while (!ct.IsCancellationRequested && ws.State == WebSocketState.Open)
                     {
                         var msg = await ReceiveWholeWsMessage(ws, ct);
-                        logger.LogInformation("WS message: type={Type} bytes={Bytes}", msg.MessageType, msg.Payload.Length);
+                        logger.LogDebug("WS message: type={Type} bytes={Bytes}", msg.MessageType, msg.Payload.Length);
                         if (msg.MessageType == WebSocketMessageType.Close)
                             break;
 
@@ -436,45 +436,6 @@ public class OpenVpnProxyController(
         } while (!result.EndOfMessage);
 
         return new WsWholeMessage(result.MessageType, ms.ToArray());
-    }
-
-    private static async Task TryDrainOptionalConnectMessage(WebSocket ws, CancellationToken ct, ILogger logger)
-    {
-        // The C++ bridge sends a text JSON immediately after handshake:
-        // {"type":"connect","proto":"udp","host":"...","port":...}
-        // Your proxy does not need it. We can safely ignore it if present.
-        if (ws.State != WebSocketState.Open)
-            return;
-
-        using var cts = CancellationTokenSource.CreateLinkedTokenSource(ct);
-        cts.CancelAfter(TimeSpan.FromMilliseconds(250));
-
-        try
-        {
-            var msg = await ReceiveWholeWsMessage(ws, cts.Token);
-            if (msg.MessageType == WebSocketMessageType.Text && msg.Payload.Length > 0)
-            {
-                var text = System.Text.Encoding.UTF8.GetString(msg.Payload);
-                if (text.Contains("\"type\":\"connect\""))
-                    logger.LogInformation("Ignored connect control message: {Text}", text);
-                else
-                    logger.LogInformation("Ignored unexpected text message: {Text}", text);
-            }
-            else if (msg.MessageType == WebSocketMessageType.Binary)
-            {
-                // If first message is binary, it is real traffic. Put it back is not possible,
-                // so we just do nothing here (and rely on normal loop in HandleUdp).
-                // In practice, C++ sends text first, so this should rarely happen.
-            }
-        }
-        catch (OperationCanceledException)
-        {
-            // No message within 250ms - fine.
-        }
-        catch (Exception e)
-        {
-            logger.LogDebug(e, "Failed to drain optional connect message. {Message}", e.Message);
-        }
     }
 
     private static async Task TryCloseWs(WebSocket ws, string reason, ILogger logger)

--- a/DataGateOpenVpnManager/DataGateOpenVpnManager.csproj
+++ b/DataGateOpenVpnManager/DataGateOpenVpnManager.csproj
@@ -5,8 +5,8 @@
         <Nullable>enable</Nullable>
         <ImplicitUsings>enable</ImplicitUsings>
         <ApplicationIcon>wwwroot\favicon.ico</ApplicationIcon>
-        <AssemblyVersion>1.2.5.54</AssemblyVersion>
-        <FileVersion>1.2.5.54</FileVersion>
+        <AssemblyVersion>1.2.5.55</AssemblyVersion>
+        <FileVersion>1.2.5.55</FileVersion>
         <RootNamespace>DataGateOpenVpnManager</RootNamespace>
     </PropertyGroup>
 

--- a/DataGateOpenVpnManager/DataGateOpenVpnManager.csproj
+++ b/DataGateOpenVpnManager/DataGateOpenVpnManager.csproj
@@ -5,8 +5,8 @@
         <Nullable>enable</Nullable>
         <ImplicitUsings>enable</ImplicitUsings>
         <ApplicationIcon>wwwroot\favicon.ico</ApplicationIcon>
-        <AssemblyVersion>1.2.5.53</AssemblyVersion>
-        <FileVersion>1.2.5.53</FileVersion>
+        <AssemblyVersion>1.2.5.54</AssemblyVersion>
+        <FileVersion>1.2.5.54</FileVersion>
         <RootNamespace>DataGateOpenVpnManager</RootNamespace>
     </PropertyGroup>
 

--- a/DataGateOpenVpnManager/Hubs/ProxyTrafficFlowHub.cs
+++ b/DataGateOpenVpnManager/Hubs/ProxyTrafficFlowHub.cs
@@ -1,0 +1,25 @@
+using Microsoft.AspNetCore.SignalR;
+
+namespace DataGateOpenVpnManager.Hubs;
+
+public class ProxyTrafficFlowHub(ILogger<ProxyTrafficFlowHub> logger) : Hub
+{
+    public override Task OnConnectedAsync()
+    {
+        logger.LogInformation("ProxyTrafficFlowHub connected: {ConnectionId}", Context.ConnectionId);
+        return base.OnConnectedAsync();
+    }
+
+    public override Task OnDisconnectedAsync(Exception? exception)
+    {
+        logger.LogInformation("ProxyTrafficFlowHub disconnected: {ConnectionId}", Context.ConnectionId);
+        return base.OnDisconnectedAsync(exception);
+    }
+
+    public Task Ping(string? instanceId = null)
+    {
+        logger.LogDebug("Heartbeat from ProxyTrafficFlowHub client {Id} (instance={Instance})",
+            Context.ConnectionId, instanceId ?? "n/a");
+        return Task.CompletedTask;
+    }
+}

--- a/DataGateOpenVpnManager/Middlewares/JwtValidationMiddleware.cs
+++ b/DataGateOpenVpnManager/Middlewares/JwtValidationMiddleware.cs
@@ -22,10 +22,16 @@ public class JwtValidationMiddleware(RequestDelegate next)
     public async Task Invoke(HttpContext context, IMicroserviceJwtValidator validator)
     {
         var requestPath = context.Request.Path;
+        var token = ExtractToken(context);
 
         // Allow unauthenticated access to Swagger and other excluded paths
         if (ExcludedPaths.Any(p => requestPath.StartsWithSegments(p, StringComparison.OrdinalIgnoreCase)))
         {
+            // For excluded paths we still attach principal when token is provided,
+            // so endpoints like /api/proxy can enrich telemetry with user identity.
+            if (!string.IsNullOrWhiteSpace(token) && validator.ValidateToken(token, out var excludedPrincipal))
+                context.User = excludedPrincipal ?? throw new InvalidOperationException("Principal is null");
+
             await next(context);
             return;
         }
@@ -39,20 +45,6 @@ public class JwtValidationMiddleware(RequestDelegate next)
             return;
         }
 
-        // Attempt to extract token from Authorization header
-        string? token = null;
-        var authHeader = context.Request.Headers["Authorization"].FirstOrDefault();
-        if (authHeader?.StartsWith("Bearer ") == true)
-        {
-            token = authHeader.Substring("Bearer ".Length);
-        }
-
-        // Fallback: check query string for access_token (e.g., for WebSocket auth)
-        if (string.IsNullOrWhiteSpace(token))
-        {
-            token = context.Request.Query["access_token"];
-        }
-
         // Validate token
         if (!string.IsNullOrWhiteSpace(token) && validator.ValidateToken(token, out var principal))
         {
@@ -64,5 +56,15 @@ public class JwtValidationMiddleware(RequestDelegate next)
         // Reject request if no valid token is found and not allowed by IP/path
         context.Response.StatusCode = 401;
         await context.Response.WriteAsync("Unauthorized");
+    }
+
+    private static string? ExtractToken(HttpContext context)
+    {
+        var authHeader = context.Request.Headers["Authorization"].FirstOrDefault();
+        if (authHeader?.StartsWith("Bearer ") == true)
+            return authHeader.Substring("Bearer ".Length);
+
+        var token = context.Request.Query["access_token"];
+        return string.IsNullOrWhiteSpace(token) ? null : token.ToString();
     }
 }

--- a/DataGateOpenVpnManager/Services/Proxy/IProxyConnectionIdentityResolver.cs
+++ b/DataGateOpenVpnManager/Services/Proxy/IProxyConnectionIdentityResolver.cs
@@ -1,0 +1,8 @@
+using Microsoft.AspNetCore.Http;
+
+namespace DataGateOpenVpnManager.Services.Proxy;
+
+public interface IProxyConnectionIdentityResolver
+{
+    ProxyConnectionIdentity? Resolve(HttpContext context, string? clientRefFromQuery);
+}

--- a/DataGateOpenVpnManager/Services/Proxy/IProxyTrafficFlowService.cs
+++ b/DataGateOpenVpnManager/Services/Proxy/IProxyTrafficFlowService.cs
@@ -1,0 +1,26 @@
+using DataGateMonitor.SharedModels.DataGateOpenVpnManager.Proxy;
+using DataGateMonitor.SharedModels.DataGateOpenVpnManager.Proxy.Enums;
+
+namespace DataGateOpenVpnManager.Services.Proxy;
+
+public interface IProxyTrafficFlowService
+{
+    void RegisterConnection(ActiveProxyConnection connection, ProxyConnectionIdentity? identity = null);
+    void UnregisterConnection(string connectionId, DateTime? disconnectedAtUtc = null);
+    void RegisterConnectFailed(
+        string connectionId,
+        ProxyConnectionProtocol protocol,
+        string? realClientIp,
+        int realClientPort,
+        ProxyConnectionIdentity? identity,
+        string targetIp,
+        int targetPort,
+        string? errorMessage,
+        DateTime? failedAtUtc = null);
+    void RecordTraffic(
+        string connectionId,
+        ProxyTrafficFlowDirection direction,
+        int bytes,
+        DateTime? occurredAtUtc = null);
+    IReadOnlyCollection<ProxyTrafficFlowUpdate> BuildBatch(DateTime emittedAtUtc);
+}

--- a/DataGateOpenVpnManager/Services/Proxy/ProxyConnectionIdentity.cs
+++ b/DataGateOpenVpnManager/Services/Proxy/ProxyConnectionIdentity.cs
@@ -1,0 +1,9 @@
+namespace DataGateOpenVpnManager.Services.Proxy;
+
+public sealed class ProxyConnectionIdentity
+{
+    public string? ClientRef { get; init; }
+    public string? UserId { get; init; }
+    public string? Username { get; init; }
+    public string? Email { get; init; }
+}

--- a/DataGateOpenVpnManager/Services/Proxy/ProxyConnectionIdentityResolver.cs
+++ b/DataGateOpenVpnManager/Services/Proxy/ProxyConnectionIdentityResolver.cs
@@ -1,0 +1,57 @@
+using System.Security.Claims;
+using Microsoft.AspNetCore.Http;
+
+namespace DataGateOpenVpnManager.Services.Proxy;
+
+public sealed class ProxyConnectionIdentityResolver : IProxyConnectionIdentityResolver
+{
+    public ProxyConnectionIdentity? Resolve(HttpContext context, string? clientRefFromQuery)
+    {
+        var clientRef = Normalize(clientRefFromQuery);
+        if (string.IsNullOrWhiteSpace(clientRef))
+            clientRef = Normalize(context.Request.Headers["X-Client-Ref"].FirstOrDefault());
+
+        var user = context.User;
+        var userId = ResolveClaim(user, ClaimTypes.NameIdentifier, "sub", "userId", "uid");
+        var username = ResolveClaim(user, ClaimTypes.Name, "preferred_username", "unique_name", "username");
+        var email = ResolveClaim(user, ClaimTypes.Email, "email");
+
+        if (string.IsNullOrWhiteSpace(userId) &&
+            string.IsNullOrWhiteSpace(username) &&
+            string.IsNullOrWhiteSpace(email) &&
+            string.IsNullOrWhiteSpace(clientRef))
+            return null;
+
+        return new ProxyConnectionIdentity
+        {
+            ClientRef = clientRef,
+            UserId = userId,
+            Username = username,
+            Email = email
+        };
+    }
+
+    private static string? ResolveClaim(ClaimsPrincipal? principal, params string[] claimTypes)
+    {
+        if (principal is null)
+            return null;
+
+        foreach (var claimType in claimTypes)
+        {
+            var value = Normalize(principal.FindFirst(claimType)?.Value);
+            if (!string.IsNullOrWhiteSpace(value))
+                return value;
+        }
+
+        return null;
+    }
+
+    private static string? Normalize(string? value)
+    {
+        if (string.IsNullOrWhiteSpace(value))
+            return null;
+
+        var trimmed = value.Trim();
+        return trimmed.Length == 0 ? null : trimmed;
+    }
+}

--- a/DataGateOpenVpnManager/Services/Proxy/ProxyTrafficFlowBroadcastService.cs
+++ b/DataGateOpenVpnManager/Services/Proxy/ProxyTrafficFlowBroadcastService.cs
@@ -1,0 +1,38 @@
+using DataGateOpenVpnManager.Hubs;
+using Microsoft.AspNetCore.SignalR;
+
+namespace DataGateOpenVpnManager.Services.Proxy;
+
+public sealed class ProxyTrafficFlowBroadcastService(
+    IProxyTrafficFlowService flowService,
+    IHubContext<ProxyTrafficFlowHub> hubContext,
+    ILogger<ProxyTrafficFlowBroadcastService> logger) : BackgroundService
+{
+    private static readonly TimeSpan BroadcastInterval = TimeSpan.FromSeconds(1);
+
+    protected override async Task ExecuteAsync(CancellationToken stoppingToken)
+    {
+        using var timer = new PeriodicTimer(BroadcastInterval);
+        while (!stoppingToken.IsCancellationRequested)
+        {
+            try
+            {
+                if (!await timer.WaitForNextTickAsync(stoppingToken))
+                    break;
+
+                var batch = flowService.BuildBatch(DateTime.UtcNow);
+                if (batch.Count == 0)
+                    continue;
+                await hubContext.Clients.All.SendAsync("TrafficFlowUpdated", batch, stoppingToken);
+            }
+            catch (OperationCanceledException) when (stoppingToken.IsCancellationRequested)
+            {
+                break;
+            }
+            catch (Exception ex)
+            {
+                logger.LogWarning(ex, "Failed to broadcast proxy traffic flow batch.");
+            }
+        }
+    }
+}

--- a/DataGateOpenVpnManager/Services/Proxy/ProxyTrafficFlowDirection.cs
+++ b/DataGateOpenVpnManager/Services/Proxy/ProxyTrafficFlowDirection.cs
@@ -1,0 +1,7 @@
+namespace DataGateOpenVpnManager.Services.Proxy;
+
+public enum ProxyTrafficFlowDirection
+{
+    ClientToServer = 0,
+    ServerToClient = 1
+}

--- a/DataGateOpenVpnManager/Services/Proxy/ProxyTrafficFlowService.cs
+++ b/DataGateOpenVpnManager/Services/Proxy/ProxyTrafficFlowService.cs
@@ -1,0 +1,243 @@
+using System.Collections.Concurrent;
+using DataGateMonitor.SharedModels.DataGateOpenVpnManager.Proxy;
+using DataGateMonitor.SharedModels.DataGateOpenVpnManager.Proxy.Enums;
+
+namespace DataGateOpenVpnManager.Services.Proxy;
+
+public sealed class ProxyTrafficFlowService : IProxyTrafficFlowService
+{
+    private static readonly TimeSpan IdleThreshold = TimeSpan.FromSeconds(10);
+
+    private readonly ConcurrentDictionary<string, FlowConnectionState> _connections = new();
+    private readonly ConcurrentQueue<ProxyTrafficFlowUpdate> _terminalUpdates = new();
+
+    public void RegisterConnection(ActiveProxyConnection connection, ProxyConnectionIdentity? identity = null)
+    {
+        var connectedAt = connection.ConnectedAtUtc == default ? DateTime.UtcNow : connection.ConnectedAtUtc;
+        var state = new FlowConnectionState(
+            connection.ConnectionId,
+            connection.Protocol,
+            connection.RealClientIp,
+            connection.RealClientPort,
+            identity?.ClientRef,
+            identity?.UserId,
+            identity?.Username,
+            identity?.Email,
+            connection.LocalProxyIp,
+            connection.LocalProxyPort,
+            connection.TargetIp,
+            connection.TargetPort,
+            connectedAt);
+
+        _connections[connection.ConnectionId] = state;
+    }
+
+    public void UnregisterConnection(string connectionId, DateTime? disconnectedAtUtc = null)
+    {
+        if (!_connections.TryRemove(connectionId, out var state))
+            return;
+
+        var emittedAt = disconnectedAtUtc ?? DateTime.UtcNow;
+        lock (state.SyncRoot)
+        {
+            _terminalUpdates.Enqueue(new ProxyTrafficFlowUpdate
+            {
+                ConnectionId = state.ConnectionId,
+                Protocol = state.Protocol,
+                State = "disconnected",
+                IsConnected = false,
+                IsIdle = true,
+                RealClientIp = state.RealClientIp,
+                RealClientPort = state.RealClientPort,
+                ClientRef = state.ClientRef,
+                UserId = state.UserId,
+                Username = state.Username,
+                Email = state.Email,
+                LocalProxyIp = state.LocalProxyIp,
+                LocalProxyPort = state.LocalProxyPort,
+                TargetIp = state.TargetIp,
+                TargetPort = state.TargetPort,
+                ClientToServerBytesTotal = state.ClientToServerBytesTotal,
+                ServerToClientBytesTotal = state.ServerToClientBytesTotal,
+                ClientToServerBytesDelta = state.ClientToServerBytesDelta,
+                ServerToClientBytesDelta = state.ServerToClientBytesDelta,
+                ConnectedAtUtc = state.ConnectedAtUtc,
+                LastActivityAtUtc = state.LastActivityAtUtc,
+                EmittedAtUtc = emittedAt
+            });
+
+            state.ClientToServerBytesDelta = 0;
+            state.ServerToClientBytesDelta = 0;
+        }
+    }
+
+    public void RegisterConnectFailed(
+        string connectionId,
+        ProxyConnectionProtocol protocol,
+        string? realClientIp,
+        int realClientPort,
+        ProxyConnectionIdentity? identity,
+        string targetIp,
+        int targetPort,
+        string? errorMessage,
+        DateTime? failedAtUtc = null)
+    {
+        var at = failedAtUtc ?? DateTime.UtcNow;
+        _terminalUpdates.Enqueue(new ProxyTrafficFlowUpdate
+        {
+            ConnectionId = connectionId,
+            Protocol = protocol,
+            State = "failed",
+            IsConnected = false,
+            IsIdle = true,
+            RealClientIp = realClientIp,
+            RealClientPort = realClientPort,
+            ClientRef = identity?.ClientRef,
+            UserId = identity?.UserId,
+            Username = identity?.Username,
+            Email = identity?.Email,
+            LocalProxyIp = null,
+            LocalProxyPort = 0,
+            TargetIp = targetIp,
+            TargetPort = targetPort,
+            ClientToServerBytesTotal = 0,
+            ServerToClientBytesTotal = 0,
+            ClientToServerBytesDelta = 0,
+            ServerToClientBytesDelta = 0,
+            ConnectedAtUtc = at,
+            LastActivityAtUtc = at,
+            EmittedAtUtc = at,
+            ErrorMessage = errorMessage
+        });
+    }
+
+    public void RecordTraffic(
+        string connectionId,
+        ProxyTrafficFlowDirection direction,
+        int bytes,
+        DateTime? occurredAtUtc = null)
+    {
+        if (bytes <= 0)
+            return;
+        if (!_connections.TryGetValue(connectionId, out var state))
+            return;
+
+        var at = occurredAtUtc ?? DateTime.UtcNow;
+        lock (state.SyncRoot)
+        {
+            if (direction == ProxyTrafficFlowDirection.ClientToServer)
+            {
+                state.ClientToServerBytesTotal += bytes;
+                state.ClientToServerBytesDelta += bytes;
+            }
+            else
+            {
+                state.ServerToClientBytesTotal += bytes;
+                state.ServerToClientBytesDelta += bytes;
+            }
+
+            state.LastActivityAtUtc = at;
+        }
+    }
+
+    public IReadOnlyCollection<ProxyTrafficFlowUpdate> BuildBatch(DateTime emittedAtUtc)
+    {
+        var result = new List<ProxyTrafficFlowUpdate>(_connections.Count + _terminalUpdates.Count);
+        foreach (var state in _connections.Values)
+        {
+            lock (state.SyncRoot)
+            {
+                var isIdle = emittedAtUtc - state.LastActivityAtUtc >= IdleThreshold;
+                result.Add(new ProxyTrafficFlowUpdate
+                {
+                    ConnectionId = state.ConnectionId,
+                    Protocol = state.Protocol,
+                    State = "connected",
+                    IsConnected = true,
+                    IsIdle = isIdle,
+                    RealClientIp = state.RealClientIp,
+                    RealClientPort = state.RealClientPort,
+                    ClientRef = state.ClientRef,
+                    UserId = state.UserId,
+                    Username = state.Username,
+                    Email = state.Email,
+                    LocalProxyIp = state.LocalProxyIp,
+                    LocalProxyPort = state.LocalProxyPort,
+                    TargetIp = state.TargetIp,
+                    TargetPort = state.TargetPort,
+                    ClientToServerBytesTotal = state.ClientToServerBytesTotal,
+                    ServerToClientBytesTotal = state.ServerToClientBytesTotal,
+                    ClientToServerBytesDelta = state.ClientToServerBytesDelta,
+                    ServerToClientBytesDelta = state.ServerToClientBytesDelta,
+                    ConnectedAtUtc = state.ConnectedAtUtc,
+                    LastActivityAtUtc = state.LastActivityAtUtc,
+                    EmittedAtUtc = emittedAtUtc
+                });
+
+                state.ClientToServerBytesDelta = 0;
+                state.ServerToClientBytesDelta = 0;
+            }
+        }
+
+        while (_terminalUpdates.TryDequeue(out var terminal))
+        {
+            result.Add(terminal);
+        }
+
+        return result;
+    }
+
+    private sealed class FlowConnectionState
+    {
+        public FlowConnectionState(
+            string connectionId,
+            ProxyConnectionProtocol protocol,
+            string? realClientIp,
+            int realClientPort,
+            string? clientRef,
+            string? userId,
+            string? username,
+            string? email,
+            string? localProxyIp,
+            int localProxyPort,
+            string? targetIp,
+            int targetPort,
+            DateTime connectedAtUtc)
+        {
+            ConnectionId = connectionId;
+            Protocol = protocol;
+            RealClientIp = realClientIp;
+            RealClientPort = realClientPort;
+            ClientRef = clientRef;
+            UserId = userId;
+            Username = username;
+            Email = email;
+            LocalProxyIp = localProxyIp;
+            LocalProxyPort = localProxyPort;
+            TargetIp = targetIp;
+            TargetPort = targetPort;
+            ConnectedAtUtc = connectedAtUtc;
+            LastActivityAtUtc = connectedAtUtc;
+        }
+
+        public object SyncRoot { get; } = new();
+        public string ConnectionId { get; }
+        public ProxyConnectionProtocol Protocol { get; }
+        public string? RealClientIp { get; }
+        public int RealClientPort { get; }
+        public string? ClientRef { get; }
+        public string? UserId { get; }
+        public string? Username { get; }
+        public string? Email { get; }
+        public string? LocalProxyIp { get; }
+        public int LocalProxyPort { get; }
+        public string? TargetIp { get; }
+        public int TargetPort { get; }
+        public DateTime ConnectedAtUtc { get; }
+        public DateTime LastActivityAtUtc { get; set; }
+        public long ClientToServerBytesTotal { get; set; }
+        public long ServerToClientBytesTotal { get; set; }
+        public long ClientToServerBytesDelta { get; set; }
+        public long ServerToClientBytesDelta { get; set; }
+    }
+}

--- a/DataGateOpenVpnManager/Services/Proxy/ProxyTrafficFlowUpdate.cs
+++ b/DataGateOpenVpnManager/Services/Proxy/ProxyTrafficFlowUpdate.cs
@@ -1,0 +1,30 @@
+using DataGateMonitor.SharedModels.DataGateOpenVpnManager.Proxy.Enums;
+
+namespace DataGateOpenVpnManager.Services.Proxy;
+
+public sealed class ProxyTrafficFlowUpdate
+{
+    public required string ConnectionId { get; init; }
+    public required ProxyConnectionProtocol Protocol { get; init; }
+    public required string State { get; init; }
+    public required bool IsConnected { get; init; }
+    public required bool IsIdle { get; init; }
+    public string? RealClientIp { get; init; }
+    public int RealClientPort { get; init; }
+    public string? ClientRef { get; init; }
+    public string? UserId { get; init; }
+    public string? Username { get; init; }
+    public string? Email { get; init; }
+    public string? LocalProxyIp { get; init; }
+    public int LocalProxyPort { get; init; }
+    public string? TargetIp { get; init; }
+    public int TargetPort { get; init; }
+    public long ClientToServerBytesTotal { get; init; }
+    public long ServerToClientBytesTotal { get; init; }
+    public long ClientToServerBytesDelta { get; init; }
+    public long ServerToClientBytesDelta { get; init; }
+    public DateTime ConnectedAtUtc { get; init; }
+    public DateTime LastActivityAtUtc { get; init; }
+    public DateTime EmittedAtUtc { get; init; }
+    public string? ErrorMessage { get; init; }
+}


### PR DESCRIPTION
Remove UDP pre-drain packet loss risk, improve TCP pump teardown under contention, and add stress plus in-memory integration tests for large payload and high concurrency proxy traffic scenarios.
