### PR TITLE
feat: ApiResponse envelopes, SignalR Newtonsoft, and OpenVPN END line parsing fix (v1.2.5.58)

### DIFF
--- a/DataGateOpenVpnManager.Tests/Controllers/CertControllerTests.cs
+++ b/DataGateOpenVpnManager.Tests/Controllers/CertControllerTests.cs
@@ -6,6 +6,7 @@ using Microsoft.Extensions.Logging;
 using Moq;
 using DataGateMonitor.SharedModels.DataGateOpenVpnManager.Cert.Requests;
 using DataGateMonitor.SharedModels.DataGateOpenVpnManager.Cert.Responses;
+using DataGateMonitor.SharedModels.Responses;
 
 namespace DataGateOpenVpnManager.Tests.Controllers;
 
@@ -32,9 +33,11 @@ public class CertControllerTests
         var result = await controller.GetAllCertificates(CancellationToken.None);
 
         var okResult = Assert.IsType<OkObjectResult>(result.Result);
-        var list = Assert.IsAssignableFrom<List<ServerCertificate>>(okResult.Value);
-        Assert.Single(list);
-        Assert.Equal("client1", list[0].CommonName);
+        var wrapped = Assert.IsType<ApiResponse<List<ServerCertificate>>>(okResult.Value);
+        Assert.True(wrapped.Success);
+        Assert.NotNull(wrapped.Data);
+        Assert.Single(wrapped.Data);
+        Assert.Equal("client1", wrapped.Data[0].CommonName);
     }
 
     [Fact]
@@ -50,7 +53,8 @@ public class CertControllerTests
         var result = await controller.GetAllCertificates(CancellationToken.None);
 
         var badRequest = Assert.IsType<BadRequestObjectResult>(result.Result);
-        Assert.NotNull(badRequest.Value);
+        var wrapped = Assert.IsType<ApiResponse<List<ServerCertificate>>>(badRequest.Value);
+        Assert.False(wrapped.Success);
     }
 
     [Fact]
@@ -72,8 +76,9 @@ public class CertControllerTests
         var result = await controller.AddServerCertificate(request, CancellationToken.None);
 
         var okResult = Assert.IsType<OkObjectResult>(result.Result);
-        var cert = Assert.IsType<ServerCertificate>(okResult.Value);
-        Assert.Equal("newclient", cert.CommonName);
+        var wrapped = Assert.IsType<ApiResponse<ServerCertificate>>(okResult.Value);
+        Assert.True(wrapped.Success);
+        Assert.Equal("newclient", wrapped.Data!.CommonName);
     }
 
     [Fact]
@@ -108,6 +113,8 @@ public class CertControllerTests
         var result = await controller.RevokeCertificate(request, CancellationToken.None);
 
         var okResult = Assert.IsType<OkObjectResult>(result.Result);
-        Assert.Equal(revokeResult, okResult.Value);
+        var wrapped = Assert.IsType<ApiResponse<ServerCertificate>>(okResult.Value);
+        Assert.True(wrapped.Success);
+        Assert.Equal(revokeResult.CommonName, wrapped.Data!.CommonName);
     }
 }

--- a/DataGateOpenVpnManager.Tests/Controllers/OpenVpnProxyControllerTests.cs
+++ b/DataGateOpenVpnManager.Tests/Controllers/OpenVpnProxyControllerTests.cs
@@ -4,6 +4,7 @@ using DataGateMonitor.SharedModels.DataGateOpenVpnManager.Proxy;
 using DataGateMonitor.SharedModels.DataGateOpenVpnManager.Proxy.Enums;
 using DataGateMonitor.SharedModels.DataGateOpenVpnManager.Proxy.Requests;
 using DataGateMonitor.SharedModels.DataGateOpenVpnManager.Proxy.Responses;
+using DataGateMonitor.SharedModels.Responses;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.Logging;
@@ -39,7 +40,10 @@ public class OpenVpnProxyControllerTests
             Host = "localhost"
         });
 
-        Assert.IsType<NotFoundResult>(result.Result);
+        var notFound = Assert.IsType<NotFoundObjectResult>(result.Result);
+        var notFoundBody = Assert.IsType<ApiResponse<ProxyClientLookupResponse>>(notFound.Value);
+        Assert.False(notFoundBody.Success);
+        Assert.Contains("No active proxy session", notFoundBody.Message);
     }
 
     [Fact]
@@ -50,7 +54,9 @@ public class OpenVpnProxyControllerTests
 
         var result = controller.GetClientByLocalPort(new GetProxyClientByLocalPortRequest { LocalPort = 0 });
 
-        Assert.IsType<BadRequestResult>(result.Result);
+        var badRequest = Assert.IsType<BadRequestObjectResult>(result.Result);
+        var badRequestBody = Assert.IsType<ApiResponse<ProxyClientLookupResponse>>(badRequest.Value);
+        Assert.False(badRequestBody.Success);
     }
 
     [Fact]
@@ -80,7 +86,10 @@ public class OpenVpnProxyControllerTests
         });
 
         var ok = Assert.IsType<OkObjectResult>(result.Result);
-        var value = Assert.IsType<ProxyClientLookupResponse>(ok.Value);
+        var wrapped = Assert.IsType<ApiResponse<ProxyClientLookupResponse>>(ok.Value);
+        Assert.True(wrapped.Success);
+        Assert.NotNull(wrapped.Data);
+        var value = wrapped.Data!;
         Assert.Equal("127.0.0.1", value.Host);
         Assert.Equal("conn-1", value.ConnectionId);
         Assert.Equal(ProxyConnectionProtocol.Udp, value.Protocol);

--- a/DataGateOpenVpnManager.Tests/DataGateOpenVpnManager.Tests.csproj
+++ b/DataGateOpenVpnManager.Tests/DataGateOpenVpnManager.Tests.csproj
@@ -17,7 +17,7 @@
         <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.3.0" />
         <PackageReference Include="Moq" Version="4.20.72" />
         <!-- DataGateMonitor.SharedModels: NuGet package only; do not use ProjectReference to the SharedModels .csproj. -->
-        <PackageReference Include="DataGateMonitor.SharedModels" Version="1.0.14" />
+        <PackageReference Include="DataGateMonitor.SharedModels" Version="1.0.20" />
         <PackageReference Include="xunit" Version="2.9.3" />
         <PackageReference Include="xunit.runner.visualstudio" Version="3.1.5">
           <PrivateAssets>all</PrivateAssets>

--- a/DataGateOpenVpnManager.Tests/Services/OpenVpnTelnet/CommandQueueTests.cs
+++ b/DataGateOpenVpnManager.Tests/Services/OpenVpnTelnet/CommandQueueTests.cs
@@ -62,6 +62,7 @@ public class CommandQueueTests
     [InlineData("NOTIFY: event occurred")]
     [InlineData("NOTICE: system message")]
     [InlineData("Command output\nEND")]
+    [InlineData("1781288640,CONNECTED,SUCCESS,10.51.30.1,,,,\nEND")]
     public async Task SendCommandAsync_WithValidResponse_ReturnsResponse(string response)
     {
         // Arrange

--- a/DataGateOpenVpnManager.Tests/Services/OpenVpnTelnet/OpenVpnManagementMessageCompletionTests.cs
+++ b/DataGateOpenVpnManager.Tests/Services/OpenVpnTelnet/OpenVpnManagementMessageCompletionTests.cs
@@ -1,0 +1,55 @@
+using DataGateOpenVpnManager.Services.OpenVpnTelnet;
+
+namespace DataGateOpenVpnManager.Tests.Services.OpenVpnTelnet;
+
+public class OpenVpnManagementMessageCompletionTests
+{
+    [Theory]
+    [InlineData("1781288640,CONNECTED,SUCCESS,10.51.30.1,,,,\nEND")]
+    [InlineData("1781288640,CONNECTED,SUCCESS,10.51.30.1,,,,\r\nEND\r\n")]
+    [InlineData("END")]
+    public void IsComplete_TrueForStateResponseEndingWithEndLine(string message)
+    {
+        Assert.True(OpenVpnManagementMessageCompletion.IsComplete(message));
+    }
+
+    [Fact]
+    public void IsComplete_FalseWhenHelpTextContainsEndWordBeforeTerminator()
+    {
+        const string partialHelp =
+            "rsa-sig                : Enter a signature in response to >RSA_SIGN challenge\n" +
+            "                         Enter signature base64 on subsequent lines followed by END\n" +
+            "pk-sig                 : Enter a signature";
+
+        Assert.False(OpenVpnManagementMessageCompletion.IsComplete(partialHelp));
+    }
+
+    [Fact]
+    public void IsComplete_TrueWhenFullHelpEndsWithEndLine()
+    {
+        const string fullHelp =
+            "rsa-sig                : Enter a signature in response to >RSA_SIGN challenge\n" +
+            "                         Enter signature base64 on subsequent lines followed by END\n" +
+            "signal s\n" +
+            "END";
+
+        Assert.True(OpenVpnManagementMessageCompletion.IsComplete(fullHelp));
+    }
+
+    [Theory]
+    [InlineData("SUCCESS: test completed")]
+    [InlineData("ERROR: test failed")]
+    [InlineData("NOTIFY: event occurred")]
+    [InlineData("NOTICE: system message")]
+    public void IsComplete_TrueForSingleLineStatusPrefixes(string message)
+    {
+        Assert.True(OpenVpnManagementMessageCompletion.IsComplete(message));
+    }
+
+    [Fact]
+    public void EndsWithEndLine_FalseForEmbeddedEndWordOnly()
+    {
+        Assert.False(OpenVpnManagementMessageCompletion.EndsWithEndLine(
+            "Enter certificate base64 on subsequent lines followed by END"));
+    }
+}

--- a/DataGateOpenVpnManager/Configurations/ServiceConfiguration.cs
+++ b/DataGateOpenVpnManager/Configurations/ServiceConfiguration.cs
@@ -56,7 +56,7 @@ public static class ServiceConfiguration
 
         services.ConfigureProxy(config);
 
-        services.AddControllers();
+        services.AddControllers().AddNewtonsoftJson();
         services.AddEndpointsApiExplorer();
         services.AddSwaggerGen();
     }

--- a/DataGateOpenVpnManager/Configurations/SignalRConfiguration.cs
+++ b/DataGateOpenVpnManager/Configurations/SignalRConfiguration.cs
@@ -1,4 +1,5 @@
 ﻿using DataGateOpenVpnManager.Hubs;
+using DataGateMonitor.Serialization;
 using DataGateMonitor.SharedModels.DataGateOpenVpnManager.Models;
 using DataGateOpenVpnManager.Services.OpenVpnTelnet;
 using Microsoft.Extensions.Options;
@@ -22,6 +23,7 @@ public static class SignalRConfiguration
 
         services.AddSingleton<OpenVpnManagementSignalService>();
         services.AddSingleton<HubConnectionTracker>(); 
-        services.AddSignalR();
+        services.AddSignalR()
+            .AddNewtonsoftJsonProtocol(options => options.PayloadSerializerSettings = ProjectJson.WebSettings);
     }
 }

--- a/DataGateOpenVpnManager/Controllers/CertController.cs
+++ b/DataGateOpenVpnManager/Controllers/CertController.cs
@@ -1,86 +1,88 @@
-﻿using DataGateOpenVpnManager.Helpers;
-using DataGateOpenVpnManager.Services.EasyRsaServices.Interfaces;
-using Microsoft.AspNetCore.Mvc;
-using DataGateMonitor.SharedModels.DataGateOpenVpnManager.Cert.Requests;
-using DataGateMonitor.SharedModels.DataGateOpenVpnManager.Cert.Responses;
-
-namespace DataGateOpenVpnManager.Controllers;
-
-[ApiController]
-[Route("api/certs")]
-public class CertController(
-    IEasyRsaService easyRsaService,
-    IEasyRsaPathResolver easyRsaPathResolver,
-    ILogger<CertController> logger)
-    : ControllerBase
-{
-    [HttpGet("get-all")]
-    public async Task<ActionResult<List<ServerCertificate>>> GetAllCertificates(CancellationToken cancellationToken)
-    {
-        try
-        {
-            var mainPath = easyRsaPathResolver.GetEasyRsaPath();
-
-            var certificates = await easyRsaService.GetAllCertificateInfoInIndexFileAsync(
-                mainPath,
-                cancellationToken);
-
-            return Ok(certificates);
-        }
-        catch (Exception ex)
-        {
-            logger.LogError(ex, "Error getting all certificates");
-            return BadRequest(new { error = ex.Message });
-        }
-    }
-    
-    [HttpPost("add")]
-    public async Task<ActionResult<ServerCertificate>> AddServerCertificate(
-        [FromBody] AddServerCertificateRequest request, CancellationToken cancellationToken)
-    {
-        try
-        {
-            var mainPath = easyRsaPathResolver.GetEasyRsaPath();
-            
-            if (request.CertExpireDays <= 0)
-            {
-                request.CertExpireDays = 365;
-            }
-
-            var result = await easyRsaService.BuildCertificateAsync(
-                mainPath,
-                cancellationToken,
-                request.CommonName,
-                request.CertExpireDays);
-
-            return Ok(result);
-        }
-        catch (Exception ex)
-        {
-            logger.LogError(ex, "Error building certificate for {CommonName}", request.CommonName);
-            return BadRequest(new { error = ex.Message });
-        }
-    }
-
-    [HttpPost("revoke")]
-    public async Task<ActionResult<ServerCertificate>> RevokeCertificate([FromBody] 
-        RevokeServerCertificateRequest request, CancellationToken cancellationToken)
-    {
-        try
-        {
-            var mainPath = easyRsaPathResolver.GetEasyRsaPath();
-
-            var result = await easyRsaService.RevokeCertificateAsync(
-                mainPath,
-                request.CommonName,
-                cancellationToken);
-
-            return Ok(result);
-        }
-        catch (Exception ex)
-        {
-            logger.LogError(ex, "Error revoking certificate for {CommonName}", request.CommonName);
-            return BadRequest(new { error = ex.Message });
-        }
-    }
-}
+﻿using DataGateOpenVpnManager.Helpers;
+using DataGateOpenVpnManager.Services.EasyRsaServices.Interfaces;
+using Microsoft.AspNetCore.Mvc;
+using DataGateMonitor.SharedModels.DataGateOpenVpnManager.Cert.Requests;
+using DataGateMonitor.SharedModels.DataGateOpenVpnManager.Cert.Responses;
+using DataGateMonitor.SharedModels.Responses;
+
+namespace DataGateOpenVpnManager.Controllers;
+
+[ApiController]
+[Route("api/certs")]
+public class CertController(
+    IEasyRsaService easyRsaService,
+    IEasyRsaPathResolver easyRsaPathResolver,
+    ILogger<CertController> logger)
+    : ControllerBase
+{
+    [HttpGet("get-all")]
+    public async Task<ActionResult<ApiResponse<List<ServerCertificate>>>> GetAllCertificates(CancellationToken cancellationToken)
+    {
+        try
+        {
+            var mainPath = easyRsaPathResolver.GetEasyRsaPath();
+
+            var certificates = await easyRsaService.GetAllCertificateInfoInIndexFileAsync(
+                mainPath,
+                cancellationToken);
+
+            return Ok(ApiResponse<List<ServerCertificate>>.SuccessResponse(certificates));
+        }
+        catch (Exception ex)
+        {
+            logger.LogError(ex, "Error getting all certificates");
+            return BadRequest(ApiResponse<List<ServerCertificate>>.ErrorResponse(ex.Message));
+        }
+    }
+    
+    [HttpPost("add")]
+    public async Task<ActionResult<ApiResponse<ServerCertificate>>> AddServerCertificate(
+        [FromBody] AddServerCertificateRequest request, CancellationToken cancellationToken)
+    {
+        try
+        {
+            var mainPath = easyRsaPathResolver.GetEasyRsaPath();
+            
+            if (request.CertExpireDays <= 0)
+            {
+                request.CertExpireDays = 365;
+            }
+
+            var result = await easyRsaService.BuildCertificateAsync(
+                mainPath,
+                cancellationToken,
+                request.CommonName,
+                request.CertExpireDays);
+
+            return Ok(ApiResponse<ServerCertificate>.SuccessResponse(result));
+        }
+        catch (Exception ex)
+        {
+            logger.LogError(ex, "Error building certificate for {CommonName}", request.CommonName);
+            return BadRequest(ApiResponse<ServerCertificate>.ErrorResponse(ex.Message));
+        }
+    }
+
+    [HttpPost("revoke")]
+    public async Task<ActionResult<ApiResponse<ServerCertificate>>> RevokeCertificate([FromBody] 
+        RevokeServerCertificateRequest request, CancellationToken cancellationToken)
+    {
+        try
+        {
+            var mainPath = easyRsaPathResolver.GetEasyRsaPath();
+
+            var result = await easyRsaService.RevokeCertificateAsync(
+                mainPath,
+                request.CommonName,
+                cancellationToken);
+
+            return Ok(ApiResponse<ServerCertificate>.SuccessResponse(result));
+        }
+        catch (Exception ex)
+        {
+            logger.LogError(ex, "Error revoking certificate for {CommonName}", request.CommonName);
+            return BadRequest(ApiResponse<ServerCertificate>.ErrorResponse(ex.Message));
+        }
+    }
+}
+

--- a/DataGateOpenVpnManager/Controllers/IndexController.cs
+++ b/DataGateOpenVpnManager/Controllers/IndexController.cs
@@ -1,6 +1,7 @@
 using System.Reflection;
 using Microsoft.AspNetCore.Mvc;
 using DataGateMonitor.SharedModels.DataGateOpenVpnManager.Info;
+using DataGateMonitor.SharedModels.Responses;
 
 namespace DataGateOpenVpnManager.Controllers;
 
@@ -13,7 +14,7 @@ public class IndexController(
     : ControllerBase
 {
     [HttpGet]
-    public async Task<ActionResult<RootOpenVpnInfoResponse>> Get(CancellationToken cancellationToken)
+    public async Task<ActionResult<ApiResponse<RootOpenVpnInfoResponse>>> Get(CancellationToken cancellationToken)
     {
         try
         {
@@ -43,12 +44,12 @@ public class IndexController(
                     BackendBaseUrl = config["BACKEND__BASEURL"]
                 }
             };
-            return Ok(response);
+            return Ok(ApiResponse<RootOpenVpnInfoResponse>.SuccessResponse(response));
         }
         catch (Exception ex)
         {
             logger.LogError(ex, "Error getting info");
-            return BadRequest(new { error = ex.Message });
+            return BadRequest(ApiResponse<RootOpenVpnInfoResponse>.ErrorResponse(ex.Message));
         }
     }
 }

--- a/DataGateOpenVpnManager/Controllers/OpenVpnProxyController.cs
+++ b/DataGateOpenVpnManager/Controllers/OpenVpnProxyController.cs
@@ -6,6 +6,7 @@ using DataGateMonitor.SharedModels.DataGateOpenVpnManager.Proxy;
 using DataGateMonitor.SharedModels.DataGateOpenVpnManager.Proxy.Enums;
 using DataGateMonitor.SharedModels.DataGateOpenVpnManager.Proxy.Requests;
 using DataGateMonitor.SharedModels.DataGateOpenVpnManager.Proxy.Responses;
+using DataGateMonitor.SharedModels.Responses;
 using Microsoft.AspNetCore.Mvc;
 
 namespace DataGateOpenVpnManager.Controllers;
@@ -28,18 +29,21 @@ public class OpenVpnProxyController(
     /// that the proxy uses toward OpenVPN (127.0.0.1:vpnPort). The dashboard often only sees loopback.
     /// </summary>
     [HttpGet("client/by-local-port")]
-    public ActionResult<ProxyClientLookupResponse> GetClientByLocalPort([FromQuery] GetProxyClientByLocalPortRequest request)
+    public ActionResult<ApiResponse<ProxyClientLookupResponse>> GetClientByLocalPort([FromQuery] GetProxyClientByLocalPortRequest request)
     {
         if (request.LocalPort is < 1 or > 65535)
-            return BadRequest();
+            return BadRequest(ApiResponse<ProxyClientLookupResponse>.ErrorResponse(
+                "Local port must be between 1 and 65535."));
 
         var host = string.IsNullOrWhiteSpace(request.Host) ? "localhost" : request.Host;
         var conn = activeProxyConnections.TryGetByLocalProxy(request.LocalPort, host);
         if (conn is null)
-            return NotFound();
+            return NotFound(ApiResponse<ProxyClientLookupResponse>.ErrorResponse(
+                "No active proxy session for the given local port."));
 
         var hostNormalized = ActiveProxyConnectionService.NormalizeHost(host);
-        return Ok(MapToProxyClientLookupResponse(conn, hostNormalized));
+        return Ok(ApiResponse<ProxyClientLookupResponse>.SuccessResponse(
+            MapToProxyClientLookupResponse(conn, hostNormalized)));
     }
 
     private static ProxyClientLookupResponse MapToProxyClientLookupResponse(ActiveProxyConnection c, string hostNormalized) =>

--- a/DataGateOpenVpnManager/Controllers/OvpnFileController.cs
+++ b/DataGateOpenVpnManager/Controllers/OvpnFileController.cs
@@ -1,94 +1,95 @@
-﻿using DataGateOpenVpnManager.Helpers;
-using DataGateOpenVpnManager.Services.Interfaces;
-using Microsoft.AspNetCore.Mvc;
-using DataGateMonitor.SharedModels.DataGateOpenVpnManager.OvpnFile.Requests;
-using DataGateMonitor.SharedModels.DataGateOpenVpnManager.OvpnFile.Responses;
-
-namespace DataGateOpenVpnManager.Controllers;
-
-[ApiController]
-[Route("api/ovpn-files")]
-public class OvpnFileController(
-    IOvpnFileService ovpnFileService,
-    IEasyRsaPathResolver easyRsaPathResolver,
-    ILogger<OvpnFileController> logger)
-    : ControllerBase
-{
-    [HttpPost("add")]
-    public async Task<ActionResult<OvpnFileMetadata>> AddOvpnFile([FromBody] GenerateOvpnFileRequest request,
-        CancellationToken cancellationToken)
-    {
-        try
-        {
-            var mainPath = easyRsaPathResolver.GetEasyRsaPath();
-
-            if (string.IsNullOrEmpty(request.CommonName) || string.IsNullOrEmpty(request.ConfigTemplate))//todo: fix
-            {
-                throw new NullReferenceException("Common name and config template are required");
-            }
-
-            var result = await ovpnFileService.AddOvpnFile(
-                mainPath,
-                request.CommonName,
-                request.FriendlyΝame,
-                request.ConfigTemplate,
-                request.ServerIp,
-                request.ServerPort,
-                cancellationToken,
-                request.IssuedTo,
-                request.OvpnFileExpireDays);
-
-            return Ok(result);
-        }
-        catch (Exception ex)
-        {
-            logger.LogError(ex, "Error added new ovpn file for {CommonName}", request.CommonName);
-            return BadRequest(new { error = ex.Message });
-        }
-    }
-
-    [HttpPost("revoke")]
-    public async Task<ActionResult<OvpnFileMetadata>> RevokeOvpnFile([FromBody] RevokeOvpnFileRequest request, 
-        CancellationToken cancellationToken)
-    {
-        try
-        {
-            var mainPath = easyRsaPathResolver.GetEasyRsaPath();
-
-            var result = await ovpnFileService.RevokeOvpnFile(
-                mainPath,
-                request.CommonName,
-                request.OvpnFileName,
-                request.OvpnFilePath,
-                cancellationToken);
-
-            return Ok(result);
-        }
-        catch (Exception ex)
-        {
-            logger.LogError(ex, "Error revoke ovpn file for {CommonName}", request.CommonName);
-            return BadRequest(new { error = ex.Message });
-        }
-    }
-
-    [HttpPost("download")]
-    public async Task<ActionResult<OvpnFileDownload>> DownloadOvpnFile([FromBody] DownloadOvpnFileRequest request,
-        CancellationToken cancellationToken)
-    {
-        try
-        {
-            var result = await ovpnFileService.GetOvpnFile(
-                request.FileName,
-                request.FilePath,
-                cancellationToken);
-
-            return Ok(result);
-        }
-        catch (Exception ex)
-        {
-            logger.LogError(ex, "Error download ovpn file for {CommonName}", request.CommonName);
-            return BadRequest(new { error = ex.Message });
-        }
-    }
-}
-
+﻿using DataGateOpenVpnManager.Helpers;
+using DataGateOpenVpnManager.Services.Interfaces;
+using Microsoft.AspNetCore.Mvc;
+using DataGateMonitor.SharedModels.DataGateOpenVpnManager.OvpnFile.Requests;
+using DataGateMonitor.SharedModels.DataGateOpenVpnManager.OvpnFile.Responses;
+using DataGateMonitor.SharedModels.Responses;
+
+namespace DataGateOpenVpnManager.Controllers;
+
+[ApiController]
+[Route("api/ovpn-files")]
+public class OvpnFileController(
+    IOvpnFileService ovpnFileService,
+    IEasyRsaPathResolver easyRsaPathResolver,
+    ILogger<OvpnFileController> logger)
+    : ControllerBase
+{
+    [HttpPost("add")]
+    public async Task<ActionResult<ApiResponse<OvpnFileMetadata>>> AddOvpnFile([FromBody] GenerateOvpnFileRequest request,
+        CancellationToken cancellationToken)
+    {
+        try
+        {
+            var mainPath = easyRsaPathResolver.GetEasyRsaPath();
+
+            if (string.IsNullOrEmpty(request.CommonName) || string.IsNullOrEmpty(request.ConfigTemplate))//todo: fix
+            {
+                throw new NullReferenceException("Common name and config template are required");
+            }
+
+            var result = await ovpnFileService.AddOvpnFile(
+                mainPath,
+                request.CommonName,
+                request.FriendlyΝame,
+                request.ConfigTemplate,
+                request.ServerIp,
+                request.ServerPort,
+                cancellationToken,
+                request.IssuedTo,
+                request.OvpnFileExpireDays);
+
+            return Ok(ApiResponse<OvpnFileMetadata>.SuccessResponse(result));
+        }
+        catch (Exception ex)
+        {
+            logger.LogError(ex, "Error added new ovpn file for {CommonName}", request.CommonName);
+            return BadRequest(ApiResponse<OvpnFileMetadata>.ErrorResponse(ex.Message));
+        }
+    }
+
+    [HttpPost("revoke")]
+    public async Task<ActionResult<ApiResponse<OvpnFileMetadata>>> RevokeOvpnFile([FromBody] RevokeOvpnFileRequest request, 
+        CancellationToken cancellationToken)
+    {
+        try
+        {
+            var mainPath = easyRsaPathResolver.GetEasyRsaPath();
+
+            var result = await ovpnFileService.RevokeOvpnFile(
+                mainPath,
+                request.CommonName,
+                request.OvpnFileName,
+                request.OvpnFilePath,
+                cancellationToken);
+
+            return Ok(ApiResponse<OvpnFileMetadata>.SuccessResponse(result));
+        }
+        catch (Exception ex)
+        {
+            logger.LogError(ex, "Error revoke ovpn file for {CommonName}", request.CommonName);
+            return BadRequest(ApiResponse<OvpnFileMetadata>.ErrorResponse(ex.Message));
+        }
+    }
+
+    [HttpPost("download")]
+    public async Task<ActionResult<ApiResponse<OvpnFileDownload>>> DownloadOvpnFile([FromBody] DownloadOvpnFileRequest request,
+        CancellationToken cancellationToken)
+    {
+        try
+        {
+            var result = await ovpnFileService.GetOvpnFile(
+                request.FileName,
+                request.FilePath,
+                cancellationToken);
+
+            return Ok(ApiResponse<OvpnFileDownload>.SuccessResponse(result));
+        }
+        catch (Exception ex)
+        {
+            logger.LogError(ex, "Error download ovpn file for {CommonName}", request.CommonName);
+            return BadRequest(ApiResponse<OvpnFileDownload>.ErrorResponse(ex.Message));
+        }
+    }
+}
+

--- a/DataGateOpenVpnManager/DataGateOpenVpnManager.csproj
+++ b/DataGateOpenVpnManager/DataGateOpenVpnManager.csproj
@@ -5,8 +5,8 @@
         <Nullable>enable</Nullable>
         <ImplicitUsings>enable</ImplicitUsings>
         <ApplicationIcon>wwwroot\favicon.ico</ApplicationIcon>
-        <AssemblyVersion>1.2.5.57</AssemblyVersion>
-        <FileVersion>1.2.5.57</FileVersion>
+        <AssemblyVersion>1.2.5.58</AssemblyVersion>
+        <FileVersion>1.2.5.58</FileVersion>
         <RootNamespace>DataGateOpenVpnManager</RootNamespace>
     </PropertyGroup>
 

--- a/DataGateOpenVpnManager/DataGateOpenVpnManager.csproj
+++ b/DataGateOpenVpnManager/DataGateOpenVpnManager.csproj
@@ -12,10 +12,11 @@
 
     <ItemGroup>
         <PackageReference Include="Elastic.Clients.Elasticsearch" Version="9.3.3" />
+        <PackageReference Include="Microsoft.AspNetCore.Mvc.NewtonsoftJson" Version="10.0.8" />
         <PackageReference Include="Microsoft.AspNetCore.OpenApi" Version="10.0.5" />
         <PackageReference Include="Newtonsoft.Json" Version="13.0.4" />
         <!-- DataGateMonitor.SharedModels: NuGet package only; do not use ProjectReference to the SharedModels .csproj. -->
-        <PackageReference Include="DataGateMonitor.SharedModels" Version="1.0.14" />
+        <PackageReference Include="DataGateMonitor.SharedModels" Version="1.0.20" />
         <PackageReference Include="Serilog" Version="4.3.1" />
         <PackageReference Include="Serilog.Extensions.Hosting" Version="10.0.0" />
         <PackageReference Include="Serilog.Extensions.Logging" Version="10.0.0" />

--- a/DataGateOpenVpnManager/DataGateOpenVpnManager.csproj
+++ b/DataGateOpenVpnManager/DataGateOpenVpnManager.csproj
@@ -5,8 +5,8 @@
         <Nullable>enable</Nullable>
         <ImplicitUsings>enable</ImplicitUsings>
         <ApplicationIcon>wwwroot\favicon.ico</ApplicationIcon>
-        <AssemblyVersion>1.2.5.56</AssemblyVersion>
-        <FileVersion>1.2.5.56</FileVersion>
+        <AssemblyVersion>1.2.5.57</AssemblyVersion>
+        <FileVersion>1.2.5.57</FileVersion>
         <RootNamespace>DataGateOpenVpnManager</RootNamespace>
     </PropertyGroup>
 

--- a/DataGateOpenVpnManager/DataGateOpenVpnManager.csproj
+++ b/DataGateOpenVpnManager/DataGateOpenVpnManager.csproj
@@ -14,6 +14,7 @@
         <PackageReference Include="Elastic.Clients.Elasticsearch" Version="9.3.3" />
         <PackageReference Include="Microsoft.AspNetCore.Mvc.NewtonsoftJson" Version="10.0.8" />
         <PackageReference Include="Microsoft.AspNetCore.OpenApi" Version="10.0.5" />
+        <PackageReference Include="Microsoft.AspNetCore.SignalR.Protocols.NewtonsoftJson" Version="10.0.8" />
         <PackageReference Include="Newtonsoft.Json" Version="13.0.4" />
         <!-- DataGateMonitor.SharedModels: NuGet package only; do not use ProjectReference to the SharedModels .csproj. -->
         <PackageReference Include="DataGateMonitor.SharedModels" Version="1.0.20" />

--- a/DataGateOpenVpnManager/DataGateOpenVpnManager.csproj
+++ b/DataGateOpenVpnManager/DataGateOpenVpnManager.csproj
@@ -5,8 +5,8 @@
         <Nullable>enable</Nullable>
         <ImplicitUsings>enable</ImplicitUsings>
         <ApplicationIcon>wwwroot\favicon.ico</ApplicationIcon>
-        <AssemblyVersion>1.2.5.55</AssemblyVersion>
-        <FileVersion>1.2.5.55</FileVersion>
+        <AssemblyVersion>1.2.5.56</AssemblyVersion>
+        <FileVersion>1.2.5.56</FileVersion>
         <RootNamespace>DataGateOpenVpnManager</RootNamespace>
     </PropertyGroup>
 

--- a/DataGateOpenVpnManager/Services/MicroserviceJwtValidator.cs
+++ b/DataGateOpenVpnManager/Services/MicroserviceJwtValidator.cs
@@ -2,8 +2,9 @@
 using System.Security.Claims;
 using System.Security.Cryptography;
 using DataGateOpenVpnManager.Services.Interfaces;
-using Microsoft.IdentityModel.Tokens;
+using DataGateMonitor.Serialization;
 using DataGateMonitor.SharedModels.Responses;
+using Microsoft.IdentityModel.Tokens;
 
 namespace DataGateOpenVpnManager.Services;
 
@@ -25,7 +26,9 @@ public class MicroserviceJwtValidator(HttpClient httpClient, ILogger<Microservic
             {
                 logger.LogInformation("🔐 Attempt to fetch public key from backend with pin {Pin}...", pin);
 
-                var response = await httpClient.GetFromJsonAsync<ApiResponse<string>>($"api/Auth/public-key/{pin}");
+                var httpResponse = await httpClient.GetAsync($"api/Auth/public-key/{pin}");
+                var json = await httpResponse.Content.ReadAsStringAsync();
+                var response = ProjectJson.Deserialize<ApiResponse<string>>(json);
 
                 if (response is { Success: true, Data: not null })
                 {

--- a/DataGateOpenVpnManager/Services/OpenVpnTelnet/CommandQueue.cs
+++ b/DataGateOpenVpnManager/Services/OpenVpnTelnet/CommandQueue.cs
@@ -70,7 +70,7 @@ public class CommandQueue : ICommandQueue, IAsyncDisposable
             }
             else
             {
-                _logger.LogWarning("[CommandQueue] No pending command found, adding to queue.");
+                _logger.LogDebug("[CommandQueue] No pending command found, adding to queue.");
                 _messageQueue.Enqueue(trimmed);
                 NotifySubscribers(trimmed, cancellationToken);
             }

--- a/DataGateOpenVpnManager/Services/OpenVpnTelnet/CommandQueue.cs
+++ b/DataGateOpenVpnManager/Services/OpenVpnTelnet/CommandQueue.cs
@@ -57,11 +57,7 @@ public class CommandQueue : ICommandQueue, IAsyncDisposable
 
         var trimmed = message.Trim();
 
-        if (trimmed.Contains("END", StringComparison.OrdinalIgnoreCase) ||
-            trimmed.Contains("SUCCESS:", StringComparison.OrdinalIgnoreCase) ||
-            trimmed.Contains("ERROR:", StringComparison.OrdinalIgnoreCase) ||
-            trimmed.Contains("NOTIFY:", StringComparison.OrdinalIgnoreCase) ||
-            trimmed.Contains("NOTICE:", StringComparison.OrdinalIgnoreCase))
+        if (OpenVpnManagementMessageCompletion.IsComplete(trimmed))
         {
             if (_pendingCommands.TryDequeue(out var pending))
             {

--- a/DataGateOpenVpnManager/Services/OpenVpnTelnet/OpenVpnManagementMessageCompletion.cs
+++ b/DataGateOpenVpnManager/Services/OpenVpnTelnet/OpenVpnManagementMessageCompletion.cs
@@ -1,0 +1,41 @@
+namespace DataGateOpenVpnManager.Services.OpenVpnTelnet;
+
+/// <summary>
+/// Detects when an OpenVPN management-interface response is complete.
+/// Multiline command output ends with <c>END</c> on its own line — not as a substring inside help text.
+/// </summary>
+public static class OpenVpnManagementMessageCompletion
+{
+    public static bool IsComplete(string message)
+    {
+        if (string.IsNullOrWhiteSpace(message))
+            return false;
+
+        if (message.Contains("SUCCESS:", StringComparison.OrdinalIgnoreCase) ||
+            message.Contains("ERROR:", StringComparison.OrdinalIgnoreCase) ||
+            message.Contains("NOTIFY:", StringComparison.OrdinalIgnoreCase) ||
+            message.Contains("NOTICE:", StringComparison.OrdinalIgnoreCase))
+            return true;
+
+        return EndsWithEndLine(message);
+    }
+
+    /// <summary>True when the last non-empty line is exactly <c>END</c> (protocol terminator).</summary>
+    public static bool EndsWithEndLine(string message)
+    {
+        if (string.IsNullOrWhiteSpace(message))
+            return false;
+
+        var lines = message.Split('\n');
+        for (var i = lines.Length - 1; i >= 0; i--)
+        {
+            var line = lines[i].Trim('\r', ' ', '\t');
+            if (line.Length == 0)
+                continue;
+
+            return line.Equals("END", StringComparison.OrdinalIgnoreCase);
+        }
+
+        return false;
+    }
+}

--- a/DataGateOpenVpnManager/Services/OpenVpnTelnet/TelnetClient.cs
+++ b/DataGateOpenVpnManager/Services/OpenVpnTelnet/TelnetClient.cs
@@ -92,10 +92,7 @@ public class TelnetClient(string host, int port, ILogger<TelnetClient> logger) :
                 response.Append(buffer, 0, bytesRead);
                 string message = response.ToString();
 
-                if (message.Contains("END") || message.Contains("SUCCESS:", StringComparison.OrdinalIgnoreCase)
-                    || message.Contains("ERROR:", StringComparison.OrdinalIgnoreCase)
-                    || message.Contains("NOTIFY:", StringComparison.OrdinalIgnoreCase)
-                    || message.Contains("NOTICE:", StringComparison.OrdinalIgnoreCase))
+                if (OpenVpnManagementMessageCompletion.IsComplete(message))
                 {
                     OnDataReceived.Invoke(message.Trim());
                     response.Clear();


### PR DESCRIPTION
## Summary

OpenVPN microservice release aligned with backend **ApiResponse** contract (**SharedModels 1.0.20**).

- **API:** Cert, OVPN file, proxy, and index controllers return `ApiResponse<T>` envelopes (consistent with main backend / dashboard client).
- **SignalR:** Newtonsoft JSON protocol configured for hub payloads (matches backend SignalR client).
- **Management telnet:** unsolicited `CommandQueue` messages logged at **Debug** (less Wazuh noise).
- **State parsing fix:** treat OpenVPN management `END` as a **line terminator**, not a substring — fixes false “incomplete response” / `UpSince` parse failures when help text contains `END`.
- **Tests:** `OpenVpnManagementMessageCompletionTests` for END-line detection; controller tests updated for wrapped responses.
- **Version:** **1.2.5.58**

## SharedModels

Uses **DataGateMonitor.SharedModels 1.0.20** (NuGet only). No bump to 1.0.24 required for this service — no new DTOs consumed here.

## Deploy notes

- Deploy **after or with** backend that expects `ApiResponse` from microservices (**≥1.0.3.41** / envelope branch).
- Rolling restart of OpenVPN manager pods/containers; no DB migrations.

## Test plan

- [ ] `dotnet restore && dotnet build && dotnet test`
- [ ] Cert generate/revoke/list — responses wrapped in `{ success, data, message }`
- [ ] OVPN file generate/download/revoke — same envelope shape
- [ ] Proxy client lookup — normal 404 lifecycle does not alert; real errors still surface
- [ ] OpenVPN `state` poll on Norway-style server: `UpSince` populated, no transient parse exception
- [ ] SignalR hub (traffic flow / status): client connects with Newtonsoft protocol, no JSON deserialize errors
- [ ] Wazuh: no WRN spam from unsolicited management queue messages during idle poll