### PR TITLE
docs: refresh README for DataGate Monitor branding and links

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,9 @@
 # DataGateOpenVpnManager + OpenVPN Docker Image
 
+OpenVPN sidecar for [DataGate Monitor](https://dash.datagateapp.com/). In the monorepo this is the `openvpn/` submodule ([DataGateMonitor](https://github.com/IMKolganov/DataGateMonitor)). Standalone clone: [DataGateOpenVpnManager](https://github.com/IMKolganov/DataGateOpenVpnManager).
+
+**Links:** [DataGate](https://datagateapp.com/) · [Download](https://datagateapp.com/download) · [Telegram @datagateapp](https://t.me/datagateapp)
+
 This project builds a Docker image containing:
 
 * A .NET 9 application: **DataGateOpenVpnManager**
@@ -136,9 +140,10 @@ services:
 
 ## 👤 Maintainer
 
-Created by **Ivan Kolganov** ❤️ based on Kyle Manna’s OpenVPN concepts.
+Created by **Ivan Kolganov** based on Kyle Manna’s OpenVPN concepts.
 
-GitHub: [IMKolganov/DataGateOpenVpnManager](https://github.com/IMKolganov/DataGateOpenVpnManager)
+- GitHub: [IMKolganov/DataGateOpenVpnManager](https://github.com/IMKolganov/DataGateOpenVpnManager)
+- [LinkedIn](https://www.linkedin.com/in/imkolganov/?locale=en) · [Telegram](https://t.me/KolganovIvan) · [Buy Me a Coffee](https://buymeacoffee.com/imkolganov)
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -2,7 +2,13 @@
 
 OpenVPN sidecar for [DataGate Monitor](https://dash.datagateapp.com/). In the monorepo this is the `openvpn/` submodule ([DataGateMonitor](https://github.com/IMKolganov/DataGateMonitor)). Standalone clone: [DataGateOpenVpnManager](https://github.com/IMKolganov/DataGateOpenVpnManager).
 
-**Links:** [DataGate](https://datagateapp.com/) · [Download](https://datagateapp.com/download) · [Telegram @datagateapp](https://t.me/datagateapp)
+**Links**
+
+| Resource | Link |
+|----------|------|
+| <img src="https://raw.githubusercontent.com/IMKolganov/DataGateMonitorFrontend/main/public/favicon.svg" width="16" height="16" alt="" /> **DataGate** | [datagateapp.com](https://datagateapp.com/) |
+| <img src="https://cdn.simpleicons.org/googleplay/414141" width="16" height="16" alt="" /> **Download** | [datagateapp.com/download](https://datagateapp.com/download) |
+| <img src="https://cdn.simpleicons.org/telegram/26A5E4" width="16" height="16" alt="" /> **Telegram channel** | [@datagateapp](https://t.me/datagateapp) |
 
 This project builds a Docker image containing:
 
@@ -142,8 +148,12 @@ services:
 
 Created by **Ivan Kolganov** based on Kyle Manna’s OpenVPN concepts.
 
-- GitHub: [IMKolganov/DataGateOpenVpnManager](https://github.com/IMKolganov/DataGateOpenVpnManager)
-- [LinkedIn](https://www.linkedin.com/in/imkolganov/?locale=en) · [Telegram](https://t.me/KolganovIvan) · [Buy Me a Coffee](https://buymeacoffee.com/imkolganov)
+| Contact | Link |
+|---------|------|
+| <img src="https://cdn.simpleicons.org/github/181717" width="16" height="16" alt="" /> **Repository** | [IMKolganov/DataGateOpenVpnManager](https://github.com/IMKolganov/DataGateOpenVpnManager) |
+| <img src="https://cdn.simpleicons.org/linkedin/0A66C2" width="16" height="16" alt="" /> **LinkedIn** | [linkedin.com/in/imkolganov](https://www.linkedin.com/in/imkolganov/?locale=en) |
+| <img src="https://cdn.simpleicons.org/telegram/26A5E4" width="16" height="16" alt="" /> **Telegram** | [@KolganovIvan](https://t.me/KolganovIvan) |
+| <img src="https://cdn.simpleicons.org/buymeacoffee/FFDD00" width="16" height="16" alt="" /> **Buy Me a Coffee** | [buymeacoffee.com/imkolganov](https://buymeacoffee.com/imkolganov) |
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -153,7 +153,7 @@ Created by **Ivan Kolganov** based on Kyle Manna’s OpenVPN concepts.
 
 | Contact | Link |
 |---------|------|
-| <img src="https://cdn.simpleicons.org/github/181717" width="16" height="16" alt="" /> **Repository** | [IMKolganov/DataGateOpenVpnManager](https://github.com/IMKolganov/DataGateOpenVpnManager) |
+| <picture><source media="(prefers-color-scheme: dark)" srcset="https://cdn.simpleicons.org/github/ffffff"><img src="https://cdn.simpleicons.org/github/181717" width="16" height="16" alt=""></picture> **Repository** | [IMKolganov/DataGateOpenVpnManager](https://github.com/IMKolganov/DataGateOpenVpnManager) |
 | <img src="https://api.iconify.design/simple-icons/linkedin.svg?color=%230A66C2" width="16" height="16" alt="" /> **LinkedIn** | [linkedin.com/in/imkolganov](https://www.linkedin.com/in/imkolganov/?locale=en) |
 | <img src="https://cdn.simpleicons.org/telegram/26A5E4" width="16" height="16" alt="" /> **Telegram** | [@KolganovIvan](https://t.me/KolganovIvan) |
 | <img src="https://cdn.simpleicons.org/buymeacoffee/FFDD00" width="16" height="16" alt="" /> **Buy Me a Coffee** | [buymeacoffee.com/imkolganov](https://buymeacoffee.com/imkolganov) |

--- a/README.md
+++ b/README.md
@@ -1,4 +1,7 @@
-# DataGateOpenVpnManager + OpenVPN Docker Image
+<h1 align="left">
+  <img src="https://raw.githubusercontent.com/IMKolganov/DataGateMonitorFrontend/main/public/favicon.svg" width="32" height="32" alt="" />
+  DataGateOpenVpnManager + OpenVPN Docker Image
+</h1>
 
 OpenVPN sidecar for [DataGate Monitor](https://dash.datagateapp.com/). In the monorepo this is the `openvpn/` submodule ([DataGateMonitor](https://github.com/IMKolganov/DataGateMonitor)). Standalone clone: [DataGateOpenVpnManager](https://github.com/IMKolganov/DataGateOpenVpnManager).
 
@@ -151,7 +154,7 @@ Created by **Ivan Kolganov** based on Kyle Manna’s OpenVPN concepts.
 | Contact | Link |
 |---------|------|
 | <img src="https://cdn.simpleicons.org/github/181717" width="16" height="16" alt="" /> **Repository** | [IMKolganov/DataGateOpenVpnManager](https://github.com/IMKolganov/DataGateOpenVpnManager) |
-| <img src="https://cdn.simpleicons.org/linkedin/0A66C2" width="16" height="16" alt="" /> **LinkedIn** | [linkedin.com/in/imkolganov](https://www.linkedin.com/in/imkolganov/?locale=en) |
+| <img src="https://api.iconify.design/simple-icons/linkedin.svg?color=%230A66C2" width="16" height="16" alt="" /> **LinkedIn** | [linkedin.com/in/imkolganov](https://www.linkedin.com/in/imkolganov/?locale=en) |
 | <img src="https://cdn.simpleicons.org/telegram/26A5E4" width="16" height="16" alt="" /> **Telegram** | [@KolganovIvan](https://t.me/KolganovIvan) |
 | <img src="https://cdn.simpleicons.org/buymeacoffee/FFDD00" width="16" height="16" alt="" /> **Buy Me a Coffee** | [buymeacoffee.com/imkolganov](https://buymeacoffee.com/imkolganov) |
 


### PR DESCRIPTION
## Summary
Documentation-only PR: refresh README(s) for **DataGate Monitor** branding and public links.
- Rename legacy **OpenVPN Gate Monitor** references to **DataGate Monitor**
- Add product links: [datagateapp.com](https://datagateapp.com/), [download](https://datagateapp.com/download), [dashboard](https://dash.datagateapp.com/), [@datagateapp](https://t.me/datagateapp)
- Add author / support links: [LinkedIn](https://www.linkedin.com/in/imkolganov/?locale=en), [Telegram](https://t.me/KolganovIvan), [Buy Me a Coffee](https://buymeacoffee.com/imkolganov)
- Expand dev quick-start (`README-DEV.md` in monorepo)
- Add DataGate logo to README title and icons in Links / Author tables
- Fix README table headers (`Resource | Link`, `Contact | Link`)
- Fix broken LinkedIn icon URL (simpleicons CDN → iconify)
- Fix GitHub icon visibility on dark theme (`<picture>` light/dark)
- Monorepo: add `docs/assets/datagate.svg` (favicon cannot live under `frontend/` submodule path)
No runtime, API, or deployment changes.
## Test plan
- [ ] Open README on GitHub (light + dark theme)
- [ ] Verify title logo, Links table icons, Author table icons render correctly
- [ ] Confirm all external links open (product, download, dashboard, Telegram, LinkedIn, BMC, GitHub)
- [ ] Monorepo only: confirm `docs/assets/datagate.svg` opens on GitHub (not `frontend/public/…`)
- [ ] No code/build changes required