### PR TITLE
Add WSS proxy diagnostics, audit logging, and UDP-WSS host tooling

### DIFF
--- a/DataGateOpenVpnManager.Tests/Configurations/ProxyConfigurationTests.cs
+++ b/DataGateOpenVpnManager.Tests/Configurations/ProxyConfigurationTests.cs
@@ -1,0 +1,38 @@
+using DataGateOpenVpnManager.Configurations;
+using DataGateOpenVpnManager.Models;
+using DataGateOpenVpnManager.Services.Proxy;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Options;
+
+namespace DataGateOpenVpnManager.Tests.Configurations;
+
+public class ProxyConfigurationTests
+{
+    [Fact]
+    public void ConfigureProxy_AppliesLegacyProxyByteDebugEnv()
+    {
+        var services = new ServiceCollection();
+        var config = new ConfigurationBuilder()
+            .AddInMemoryCollection(new Dictionary<string, string?> { ["PROXY_BYTE_DEBUG"] = "1" })
+            .Build();
+
+        services.ConfigureProxy(config);
+        var options = services.BuildServiceProvider().GetRequiredService<IOptions<OpenVpnProxyOptions>>().Value;
+
+        Assert.True(options.ByteDebug);
+    }
+
+    [Fact]
+    public void ConfigureProxy_RegistersProxyServices()
+    {
+        var services = new ServiceCollection();
+        var config = new ConfigurationBuilder().Build();
+        services.AddLogging();
+        services.ConfigureProxy(config);
+        var provider = services.BuildServiceProvider();
+
+        Assert.NotNull(provider.GetService<IProxySessionAuditService>());
+        Assert.NotNull(provider.GetService<IProxyConnectionLifetimeService>());
+    }
+}

--- a/DataGateOpenVpnManager.Tests/Controllers/DiagnosticsControllerTests.cs
+++ b/DataGateOpenVpnManager.Tests/Controllers/DiagnosticsControllerTests.cs
@@ -4,6 +4,7 @@ using DataGateOpenVpnManager.Services.OpenVpnTelnet;
 using DataGateOpenVpnManager.Services.Proxy;
 using DataGateOpenVpnManager.Tests.Services.OpenVpnTelnet.Fakes;
 using DataGateOpenVpnManager.Tests.Services.Proxy;
+using DataGateMonitor.SharedModels.DataGateOpenVpnManager.Diagnostics.Responses;
 using DataGateMonitor.SharedModels.DataGateOpenVpnManager.Proxy;
 using DataGateMonitor.SharedModels.DataGateOpenVpnManager.Proxy.Enums;
 using DataGateMonitor.SharedModels.Responses;

--- a/DataGateOpenVpnManager.Tests/Controllers/DiagnosticsControllerTests.cs
+++ b/DataGateOpenVpnManager.Tests/Controllers/DiagnosticsControllerTests.cs
@@ -1,0 +1,138 @@
+using DataGateOpenVpnManager.Controllers;
+using DataGateOpenVpnManager.Models;
+using DataGateOpenVpnManager.Services.OpenVpnTelnet;
+using DataGateOpenVpnManager.Services.Proxy;
+using DataGateOpenVpnManager.Tests.Services.OpenVpnTelnet.Fakes;
+using DataGateOpenVpnManager.Tests.Services.Proxy;
+using DataGateMonitor.SharedModels.DataGateOpenVpnManager.Proxy;
+using DataGateMonitor.SharedModels.DataGateOpenVpnManager.Proxy.Enums;
+using DataGateMonitor.SharedModels.Responses;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.Logging.Abstractions;
+using Microsoft.Extensions.Options;
+using Moq;
+
+namespace DataGateOpenVpnManager.Tests.Controllers;
+
+public class DiagnosticsControllerTests
+{
+    private static DiagnosticsController CreateController(
+        IActiveProxyConnectionService? active = null,
+        IOpenVpnManagementStatusCache? cache = null,
+        IProxySessionAuditService? audit = null,
+        IConfiguration? config = null,
+        OpenVpnProxyOptions? options = null)
+    {
+        var configuration = config ?? new ConfigurationBuilder()
+            .AddInMemoryCollection(new Dictionary<string, string?> { ["DNS1"] = "10.51.15.1" })
+            .Build();
+
+        return new DiagnosticsController(
+            configuration,
+            Options.Create(options ?? new OpenVpnProxyOptions()),
+            active ?? new ActiveProxyConnectionService(),
+            new ProxyTrafficFlowService(),
+            cache ?? new OpenVpnManagementStatusCache(null!, new NoOpProxySessionAuditService(), NullLogger<OpenVpnManagementStatusCache>.Instance),
+            audit ?? new ProxySessionAuditService(Options.Create(new OpenVpnProxyOptions { SessionAudit = true }), NullLogger<ProxySessionAuditService>.Instance),
+            NullLogger<DiagnosticsController>.Instance);
+    }
+
+    [Fact]
+    public void GetProxyAudit_ReturnsRecentEntries()
+    {
+        var audit = new ProxySessionAuditService(
+            Options.Create(new OpenVpnProxyOptions { SessionAudit = true }),
+            NullLogger<ProxySessionAuditService>.Instance);
+        audit.Record(new ProxySessionAuditEntry
+        {
+            AtUtc = DateTime.UtcNow,
+            Event = "proxy.connected",
+            ConnectionId = "c1",
+            Decision = "ok",
+            Reason = "Udp"
+        });
+
+        var controller = CreateController(audit: audit);
+        var result = controller.GetProxyAudit(10);
+
+        var ok = Assert.IsType<OkObjectResult>(result.Result);
+        var response = Assert.IsType<ApiResponse<ProxyAuditDiagnosticsResponse>>(ok.Value);
+        Assert.True(response.Success);
+        Assert.Single(response.Data!.Entries);
+    }
+
+    [Fact]
+    public async Task GetProxySessions_MarksZombieOnlyWhenEvaluationAvailable()
+    {
+        var active = new ActiveProxyConnectionService();
+        active.Add(new ActiveProxyConnection
+        {
+            ConnectionId = "live",
+            Protocol = ProxyConnectionProtocol.Udp,
+            RealClientIp = "203.0.113.1",
+            RealClientPort = 50000,
+            LocalProxyIp = "127.0.0.1",
+            LocalProxyPort = 60123,
+            TargetIp = "127.0.0.1",
+            TargetPort = 1194,
+            ConnectedAtUtc = DateTime.UtcNow.AddMinutes(-1)
+        });
+
+        var telnet = new FakeTelnetClient();
+        var management = new OpenVpnManagementSignalService(telnet, NullLogger<CommandQueue>.Instance);
+        var cache = new OpenVpnManagementStatusCache(management, new NoOpProxySessionAuditService(), NullLogger<OpenVpnManagementStatusCache>.Instance);
+        var refreshTask = cache.RefreshAsync(CancellationToken.None);
+        telnet.SimulateIncomingData("END");
+        await refreshTask;
+
+        var controller = CreateController(active, cache);
+        var result = await controller.GetProxySessions(CancellationToken.None);
+
+        var ok = Assert.IsType<OkObjectResult>(result.Result);
+        var response = Assert.IsType<ApiResponse<ProxySessionDiagnosticsResponse>>(ok.Value);
+        Assert.True(response.Success);
+        Assert.False(response.Data!.PeerEvaluationAvailable);
+        Assert.Equal("client_list_empty", response.Data.PeerEvaluationSkipReason);
+        var session = Assert.Single(response.Data.Sessions);
+        Assert.True(session.MissingFromManagement);
+        Assert.False(session.IsZombie);
+    }
+
+    [Fact]
+    public async Task GetProxySessions_ReportsLiveSession_WhenPeerInManagement()
+    {
+        var active = new ActiveProxyConnectionService();
+        active.Add(new ActiveProxyConnection
+        {
+            ConnectionId = "live",
+            Protocol = ProxyConnectionProtocol.Udp,
+            RealClientIp = "203.0.113.1",
+            RealClientPort = 50000,
+            LocalProxyIp = "127.0.0.1",
+            LocalProxyPort = 60123,
+            TargetIp = "127.0.0.1",
+            TargetPort = 1194,
+            ConnectedAtUtc = DateTime.UtcNow.AddMinutes(-1)
+        });
+
+        var telnet = new FakeTelnetClient();
+        var management = new OpenVpnManagementSignalService(telnet, NullLogger<CommandQueue>.Instance);
+        var cache = new OpenVpnManagementStatusCache(management, new NoOpProxySessionAuditService(), NullLogger<OpenVpnManagementStatusCache>.Instance);
+        var refreshTask = cache.RefreshAsync(CancellationToken.None);
+        telnet.SimulateIncomingData(
+            "CLIENT_LIST\tadg-77\t127.0.0.1:60123\t10.51.16.3\t\t1000\t2000\t1748337500\tUNDEF\nEND");
+        await refreshTask;
+
+        var controller = CreateController(active, cache);
+        var result = await controller.GetProxySessions(CancellationToken.None);
+
+        var ok = Assert.IsType<OkObjectResult>(result.Result);
+        var response = Assert.IsType<ApiResponse<ProxySessionDiagnosticsResponse>>(ok.Value);
+        var session = Assert.Single(response.Data!.Sessions);
+        Assert.False(session.MissingFromManagement);
+        Assert.False(session.IsZombie);
+        Assert.Equal("adg-77", session.OpenVpnCommonName);
+        Assert.Equal("host-default-route", response.Data.DnsProbeScope);
+    }
+}

--- a/DataGateOpenVpnManager.Tests/Controllers/IndexControllerTests.cs
+++ b/DataGateOpenVpnManager.Tests/Controllers/IndexControllerTests.cs
@@ -5,6 +5,7 @@ using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.Logging;
 using Moq;
 using DataGateMonitor.SharedModels.DataGateOpenVpnManager.Info;
+using DataGateMonitor.SharedModels.Responses;
 
 namespace DataGateOpenVpnManager.Tests.Controllers;
 
@@ -45,14 +46,15 @@ public class IndexControllerTests
         var result = await controller.Get(CancellationToken.None);
 
         var okResult = Assert.IsType<OkObjectResult>(result.Result);
-        var response = Assert.IsType<RootOpenVpnInfoResponse>(okResult.Value);
-        Assert.Equal("DataGateOpenVpnManager", response.Application);
-        Assert.Equal("Testing", response.Environment);
-        Assert.NotNull(response.Version);
-        Assert.NotNull(response.Config);
-        Assert.Equal("8.8.8.8", response.Config.Dns1);
-        Assert.Equal("1194", response.Config.Port);
-        Assert.Equal("5092", response.Config.OpenVpnManagement?.Port);
+        var response = Assert.IsType<ApiResponse<RootOpenVpnInfoResponse>>(okResult.Value);
+        Assert.True(response.Success);
+        Assert.Equal("DataGateOpenVpnManager", response.Data!.Application);
+        Assert.Equal("Testing", response.Data.Environment);
+        Assert.NotNull(response.Data.Version);
+        Assert.NotNull(response.Data.Config);
+        Assert.Equal("8.8.8.8", response.Data.Config.Dns1);
+        Assert.Equal("1194", response.Data.Config.Port);
+        Assert.Equal("5092", response.Data.Config.OpenVpnManagement?.Port);
     }
 
     [Fact]
@@ -64,7 +66,7 @@ public class IndexControllerTests
         var result = await controller.Get(CancellationToken.None);
 
         var okResult = Assert.IsType<OkObjectResult>(result.Result);
-        var response = Assert.IsType<RootOpenVpnInfoResponse>(okResult.Value);
-        Assert.NotNull(response.Config);
+        var response = Assert.IsType<ApiResponse<RootOpenVpnInfoResponse>>(okResult.Value);
+        Assert.NotNull(response.Data!.Config);
     }
 }

--- a/DataGateOpenVpnManager.Tests/Controllers/OpenVpnProxyControllerIntegrationTests.cs
+++ b/DataGateOpenVpnManager.Tests/Controllers/OpenVpnProxyControllerIntegrationTests.cs
@@ -2,6 +2,7 @@ using System.Net.Sockets;
 using System.Net.WebSockets;
 using DataGateOpenVpnManager.Controllers;
 using DataGateOpenVpnManager.Services.Proxy;
+using DataGateOpenVpnManager.Tests.Services.Proxy;
 using DataGateMonitor.SharedModels.DataGateOpenVpnManager.Proxy;
 using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Hosting;
@@ -91,6 +92,9 @@ public class OpenVpnProxyControllerIntegrationTests
                 services.AddSingleton<IProxyConnectionHistoryService>(history);
                 services.AddSingleton<IProxyTrafficFlowService>(flow);
                 services.AddSingleton<IProxyConnectionIdentityResolver>(identityResolver);
+                services.AddSingleton<IProxyByteDebugService>(new NoOpProxyByteDebugService());
+                services.AddSingleton<IProxyConnectionLifetimeService, ProxyConnectionLifetimeService>();
+                services.AddSingleton<IProxySessionAuditService, NoOpProxySessionAuditService>();
                 services.AddSingleton(NullLogger<OpenVpnProxyController>.Instance);
                 services.AddControllers().AddApplicationPart(typeof(OpenVpnProxyController).Assembly);
             })
@@ -175,6 +179,13 @@ public class OpenVpnProxyControllerIntegrationTests
         }
 
         Assert.True(condition(), "Condition was not met before timeout.");
+    }
+
+    private sealed class NoOpProxyByteDebugService : IProxyByteDebugService
+    {
+        public void ReportDisconnect(ProxyTrafficFlowUpdate update)
+        {
+        }
     }
 
     private sealed class TcpEchoServer : IAsyncDisposable

--- a/DataGateOpenVpnManager.Tests/Controllers/OpenVpnProxyControllerTests.cs
+++ b/DataGateOpenVpnManager.Tests/Controllers/OpenVpnProxyControllerTests.cs
@@ -1,5 +1,6 @@
 using DataGateOpenVpnManager.Controllers;
 using DataGateOpenVpnManager.Services.Proxy;
+using DataGateOpenVpnManager.Tests.Services.Proxy;
 using DataGateMonitor.SharedModels.DataGateOpenVpnManager.Proxy;
 using DataGateMonitor.SharedModels.DataGateOpenVpnManager.Proxy.Enums;
 using DataGateMonitor.SharedModels.DataGateOpenVpnManager.Proxy.Requests;
@@ -18,14 +19,20 @@ public class OpenVpnProxyControllerTests
         IActiveProxyConnectionService active,
         IProxyConnectionHistoryService? history = null,
         IProxyTrafficFlowService? trafficFlow = null,
-        IProxyConnectionIdentityResolver? identityResolver = null)
+        IProxyConnectionIdentityResolver? identityResolver = null,
+        IProxyByteDebugService? byteDebug = null,
+        IProxyConnectionLifetimeService? lifetime = null,
+        IProxySessionAuditService? sessionAudit = null)
     {
         var config = new ConfigurationBuilder().AddInMemoryCollection().Build();
         var logger = new Mock<ILogger<OpenVpnProxyController>>();
         history ??= new Mock<IProxyConnectionHistoryService>().Object;
         trafficFlow ??= new Mock<IProxyTrafficFlowService>().Object;
         identityResolver ??= new Mock<IProxyConnectionIdentityResolver>().Object;
-        return new OpenVpnProxyController(config, logger.Object, active, history, trafficFlow, identityResolver);
+        byteDebug ??= new Mock<IProxyByteDebugService>().Object;
+        lifetime ??= new Mock<IProxyConnectionLifetimeService>().Object;
+        sessionAudit ??= new NoOpProxySessionAuditService();
+        return new OpenVpnProxyController(config, logger.Object, active, history, trafficFlow, identityResolver, byteDebug, lifetime, sessionAudit);
     }
 
     [Fact]

--- a/DataGateOpenVpnManager.Tests/Controllers/OvpnFileControllerTests.cs
+++ b/DataGateOpenVpnManager.Tests/Controllers/OvpnFileControllerTests.cs
@@ -1,11 +1,12 @@
 using DataGateOpenVpnManager.Controllers;
 using DataGateOpenVpnManager.Helpers;
 using DataGateOpenVpnManager.Services.Interfaces;
+using DataGateMonitor.SharedModels.DataGateOpenVpnManager.OvpnFile.Requests;
+using DataGateMonitor.SharedModels.DataGateOpenVpnManager.OvpnFile.Responses;
+using DataGateMonitor.SharedModels.Responses;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.Extensions.Logging;
 using Moq;
-using DataGateMonitor.SharedModels.DataGateOpenVpnManager.OvpnFile.Requests;
-using DataGateMonitor.SharedModels.DataGateOpenVpnManager.OvpnFile.Responses;
 
 namespace DataGateOpenVpnManager.Tests.Controllers;
 
@@ -38,7 +39,9 @@ public class OvpnFileControllerTests
         var result = await controller.AddOvpnFile(request, CancellationToken.None);
 
         var okResult = Assert.IsType<OkObjectResult>(result.Result);
-        Assert.Equal(metadata, okResult.Value);
+        var response = Assert.IsType<ApiResponse<OvpnFileMetadata>>(okResult.Value);
+        Assert.True(response.Success);
+        Assert.Equal(metadata.CommonName, response.Data!.CommonName);
     }
 
     [Fact]
@@ -69,7 +72,9 @@ public class OvpnFileControllerTests
         var result = await controller.RevokeOvpnFile(request, CancellationToken.None);
 
         var okResult = Assert.IsType<OkObjectResult>(result.Result);
-        Assert.Equal(metadata, okResult.Value);
+        var response = Assert.IsType<ApiResponse<OvpnFileMetadata>>(okResult.Value);
+        Assert.True(response.Success);
+        Assert.Equal(metadata.CommonName, response.Data!.CommonName);
     }
 
     [Fact]
@@ -85,8 +90,9 @@ public class OvpnFileControllerTests
         var result = await controller.DownloadOvpnFile(request, CancellationToken.None);
 
         var okResult = Assert.IsType<OkObjectResult>(result.Result);
-        var resp = Assert.IsType<OvpnFileDownload>(okResult.Value);
-        Assert.NotNull(resp.Content);
-        Assert.Equal(3, resp.Content.Length);
+        var response = Assert.IsType<ApiResponse<OvpnFileDownload>>(okResult.Value);
+        Assert.True(response.Success);
+        Assert.NotNull(response.Data!.Content);
+        Assert.Equal(3, response.Data.Content.Length);
     }
 }

--- a/DataGateOpenVpnManager.Tests/Controllers/VpnEventControllerTests.cs
+++ b/DataGateOpenVpnManager.Tests/Controllers/VpnEventControllerTests.cs
@@ -54,6 +54,38 @@ public class VpnEventControllerTests
     }
 
     [Fact]
+    public async Task OnClientAttempt_ReturnsOk()
+    {
+        var clientProxyMock = new Mock<IClientProxy>();
+        clientProxyMock.Setup(c => c.SendCoreAsync("ClientAttempted", It.IsAny<object[]>(), It.IsAny<CancellationToken>()))
+            .Returns(Task.CompletedTask);
+        var hubContext = CreateHubContextMock(clientProxyMock.Object);
+
+        var controller = new VpnEventController(_loggerMock.Object, hubContext);
+        var data = new VpnEventRequest { CommonName = "client1", VirtualAddress = "10.51.16.2" };
+
+        var result = await controller.OnClientAttempt(data, CancellationToken.None);
+
+        Assert.IsType<OkResult>(result);
+    }
+
+    [Fact]
+    public async Task OnTlsVerify_ReturnsOk()
+    {
+        var clientProxyMock = new Mock<IClientProxy>();
+        clientProxyMock.Setup(c => c.SendCoreAsync("TlsVerified", It.IsAny<object[]>(), It.IsAny<CancellationToken>()))
+            .Returns(Task.CompletedTask);
+        var hubContext = CreateHubContextMock(clientProxyMock.Object);
+
+        var controller = new VpnEventController(_loggerMock.Object, hubContext);
+        var data = new VpnEventRequest { CommonName = "client1", Message = "ok" };
+
+        var result = await controller.OnTlsVerify(data, CancellationToken.None);
+
+        Assert.IsType<OkResult>(result);
+    }
+
+    [Fact]
     public async Task OnError_ReturnsOk_AndSendsErrorEvent()
     {
         var clientProxyMock = new Mock<IClientProxy>();

--- a/DataGateOpenVpnManager.Tests/DataGateOpenVpnManager.Tests.csproj
+++ b/DataGateOpenVpnManager.Tests/DataGateOpenVpnManager.Tests.csproj
@@ -17,7 +17,7 @@
         <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.3.0" />
         <PackageReference Include="Moq" Version="4.20.72" />
         <!-- DataGateMonitor.SharedModels: NuGet package only; do not use ProjectReference to the SharedModels .csproj. -->
-        <PackageReference Include="DataGateMonitor.SharedModels" Version="1.0.20" />
+        <PackageReference Include="DataGateMonitor.SharedModels" Version="1.0.25" />
         <PackageReference Include="xunit" Version="2.9.3" />
         <PackageReference Include="xunit.runner.visualstudio" Version="3.1.5">
           <PrivateAssets>all</PrivateAssets>

--- a/DataGateOpenVpnManager.Tests/Middlewares/JwtValidationMiddlewareTests.cs
+++ b/DataGateOpenVpnManager.Tests/Middlewares/JwtValidationMiddlewareTests.cs
@@ -73,6 +73,8 @@ public class JwtValidationMiddlewareTests
     }
 
     [Theory]
+    [InlineData("/api/info")]
+    [InlineData("/api/diagnostics/proxy-audit")]
     [InlineData("/api/vpn-events/connect")]
     [InlineData("/api/vpn-events/disconnect")]
     public async Task Invoke_WhenLocalOnlyPathAndLoopback_CallsNext(string path)

--- a/DataGateOpenVpnManager.Tests/Models/OpenVpnProxyOptionsTests.cs
+++ b/DataGateOpenVpnManager.Tests/Models/OpenVpnProxyOptionsTests.cs
@@ -1,0 +1,34 @@
+using DataGateOpenVpnManager.Models;
+
+namespace DataGateOpenVpnManager.Tests.Models;
+
+public class OpenVpnProxyOptionsTests
+{
+    [Fact]
+    public void IsSessionAuditEnabled_WhenByteDebugOrSessionAudit()
+    {
+        Assert.True(new OpenVpnProxyOptions { ByteDebug = true }.IsSessionAuditEnabled);
+        Assert.True(new OpenVpnProxyOptions { SessionAudit = true }.IsSessionAuditEnabled);
+        Assert.False(new OpenVpnProxyOptions().IsSessionAuditEnabled);
+    }
+
+    [Theory]
+    [InlineData(true, 10, true)]
+    [InlineData(false, 10, true)]
+    [InlineData(true, 0, false)]
+    [InlineData(false, 0, false)]
+    public void NeedsBackgroundManagementRefresh_ReflectsZombieAndPeriodicByteDebug(
+        bool byteDebug,
+        int byteDebugInterval,
+        bool zombieEnabled)
+    {
+        var options = new OpenVpnProxyOptions
+        {
+            ByteDebug = byteDebug,
+            ByteDebugIntervalSeconds = byteDebugInterval,
+            CloseZombieAfterMissingSeconds = zombieEnabled ? 60 : 0
+        };
+
+        Assert.Equal(zombieEnabled || byteDebug && byteDebugInterval > 0, options.NeedsBackgroundManagementRefresh);
+    }
+}

--- a/DataGateOpenVpnManager.Tests/Services/EasyRsaServices/EasyRsaServiceTests.cs
+++ b/DataGateOpenVpnManager.Tests/Services/EasyRsaServices/EasyRsaServiceTests.cs
@@ -1,0 +1,42 @@
+using DataGateOpenVpnManager.Services.EasyRsaServices;
+using DataGateOpenVpnManager.Services.EasyRsaServices.Interfaces;
+using DataGateOpenVpnManager.Services.Interfaces;
+using Microsoft.Extensions.Logging.Abstractions;
+using Moq;
+
+namespace DataGateOpenVpnManager.Tests.Services.EasyRsaServices;
+
+public class EasyRsaServiceTests
+{
+    [Fact]
+    public async Task RevokeCertificateAsync_WhenIssuedCertMissing_ThrowsFileNotFound()
+    {
+        var tempDir = Path.Combine(Path.GetTempPath(), "EasyRsa_" + Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(Path.Combine(tempDir, "pki", "issued"));
+
+        var service = new EasyRsaService(
+            NullLogger<IEasyRsaService>.Instance,
+            Mock.Of<IEasyRsaParseDbService>(),
+            Mock.Of<IBashCommandRunner>(),
+            Mock.Of<IOpenVpnServerService>());
+
+        try
+        {
+            await Assert.ThrowsAsync<FileNotFoundException>(() =>
+                service.RevokeCertificateAsync(tempDir, "missing-client", CancellationToken.None));
+        }
+        finally
+        {
+            Directory.Delete(tempDir, recursive: true);
+        }
+    }
+
+    private static string CreateEasyRsaLayout(string commonName)
+    {
+        var tempDir = Path.Combine(Path.GetTempPath(), "EasyRsa_" + Guid.NewGuid().ToString("N"));
+        var issuedDir = Path.Combine(tempDir, "pki", "issued");
+        Directory.CreateDirectory(issuedDir);
+        File.WriteAllText(Path.Combine(issuedDir, $"{commonName}.crt"), "dummy cert");
+        return tempDir;
+    }
+}

--- a/DataGateOpenVpnManager.Tests/Services/MicroserviceJwtValidatorTests.cs
+++ b/DataGateOpenVpnManager.Tests/Services/MicroserviceJwtValidatorTests.cs
@@ -1,0 +1,144 @@
+using System.IdentityModel.Tokens.Jwt;
+using System.Net;
+using System.Security.Claims;
+using System.Security.Cryptography;
+using System.Text;
+using DataGateMonitor.Serialization;
+using DataGateMonitor.SharedModels.Responses;
+using DataGateOpenVpnManager.Services;
+using DataGateOpenVpnManager.Services.Interfaces;
+using Microsoft.Extensions.Logging.Abstractions;
+using Microsoft.IdentityModel.Tokens;
+using Moq;
+
+namespace DataGateOpenVpnManager.Tests.Services;
+
+public class MicroserviceJwtValidatorTests
+{
+    [Fact]
+    public void ValidateToken_ReturnsTrue_ForValidBackendToken()
+    {
+        using var rsa = RSA.Create(2048);
+        var validator = CreateValidatorWithPublicKey(rsa);
+        var token = CreateToken(rsa);
+
+        var valid = validator.ValidateToken(token, out var principal);
+
+        Assert.True(valid);
+        Assert.NotNull(principal);
+        Assert.Equal("backend", principal!.FindFirst(ClaimTypes.Role)?.Value);
+    }
+
+    [Fact]
+    public void ValidateToken_ReturnsFalse_WhenPurposeClaimMissing()
+    {
+        using var rsa = RSA.Create(2048);
+        var validator = CreateValidatorWithPublicKey(rsa);
+        var token = CreateToken(rsa, includePurpose: false);
+
+        Assert.False(validator.ValidateToken(token, out var principal));
+        Assert.Null(principal);
+    }
+
+    [Fact]
+    public async Task InitAsync_LoadsPublicKeyFromBackend()
+    {
+        using var rsa = RSA.Create(2048);
+        var publicPem = rsa.ExportRSAPublicKeyPem();
+        var handler = new StubHttpMessageHandler(_ =>
+        {
+            var json = ProjectJson.Serialize(ApiResponse<string>.SuccessResponse(publicPem));
+            return new HttpResponseMessage(HttpStatusCode.OK)
+            {
+                Content = new StringContent(json, Encoding.UTF8, "application/json")
+            };
+        });
+
+        var validator = new MicroserviceJwtValidator(
+            new HttpClient(handler) { BaseAddress = new Uri("http://localhost:9999/") },
+            NullLogger<MicroserviceJwtValidator>.Instance);
+        await validator.InitAsync();
+
+        var token = CreateToken(rsa);
+        Assert.True(validator.ValidateToken(token, out _));
+    }
+
+    private static MicroserviceJwtValidator CreateValidatorWithPublicKey(RSA rsa)
+    {
+        var validator = new MicroserviceJwtValidator(new HttpClient(new StubHttpMessageHandler(_ => new HttpResponseMessage())), NullLogger<MicroserviceJwtValidator>.Instance);
+        typeof(MicroserviceJwtValidator)
+            .GetField("_publicKey", System.Reflection.BindingFlags.Instance | System.Reflection.BindingFlags.NonPublic)!
+            .SetValue(validator, rsa.ExportRSAPublicKeyPem());
+        return validator;
+    }
+
+    private static string CreateToken(RSA rsa, bool includePurpose = true)
+    {
+        var claims = new List<Claim> { new(ClaimTypes.Role, "backend") };
+        if (includePurpose)
+            claims.Add(new Claim("purpose", "cert-create"));
+
+        var token = new JwtSecurityToken(
+            issuer: "OpenVPNGateBackend",
+            audience: "DataGateOpenVpnManager",
+            claims: claims,
+            expires: DateTime.UtcNow.AddHours(1),
+            signingCredentials: new SigningCredentials(new RsaSecurityKey(rsa), SecurityAlgorithms.RsaSha256));
+
+        return new JwtSecurityTokenHandler().WriteToken(token);
+    }
+}
+
+internal sealed class StubHttpMessageHandler(Func<HttpRequestMessage, HttpResponseMessage> responder)
+    : HttpMessageHandler
+{
+    protected override Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken) =>
+        Task.FromResult(responder(request));
+}
+
+public class MicroserviceJwtValidatorInitializerTests
+{
+    [Fact]
+    public async Task StartAsync_CallsInitOnConcreteValidator()
+    {
+        using var rsa = RSA.Create(2048);
+        var handler = new StubHttpMessageHandler(_ =>
+        {
+            var json = ProjectJson.Serialize(ApiResponse<string>.SuccessResponse(rsa.ExportRSAPublicKeyPem()));
+            return new HttpResponseMessage(HttpStatusCode.OK)
+            {
+                Content = new StringContent(json, Encoding.UTF8, "application/json")
+            };
+        });
+
+        var validator = new MicroserviceJwtValidator(new HttpClient(handler) { BaseAddress = new Uri("http://localhost:9999/") }, NullLogger<MicroserviceJwtValidator>.Instance);
+        var initializer = new MicroserviceJwtValidatorInitializer(validator);
+        await initializer.StartAsync(CancellationToken.None);
+
+        var token = CreateSmokeToken(rsa);
+        Assert.True(validator.ValidateToken(token, out _));
+    }
+
+    [Fact]
+    public async Task StopAsync_Completes()
+    {
+        var initializer = new MicroserviceJwtValidatorInitializer(Mock.Of<IMicroserviceJwtValidator>());
+        await initializer.StopAsync(CancellationToken.None);
+    }
+
+    private static string CreateSmokeToken(RSA rsa)
+    {
+        var token = new JwtSecurityToken(
+            issuer: "OpenVPNGateBackend",
+            audience: "DataGateOpenVpnManager",
+            claims:
+            [
+                new Claim("purpose", "cert-create"),
+                new Claim(ClaimTypes.Role, "backend")
+            ],
+            expires: DateTime.UtcNow.AddHours(1),
+            signingCredentials: new SigningCredentials(new RsaSecurityKey(rsa), SecurityAlgorithms.RsaSha256));
+
+        return new JwtSecurityTokenHandler().WriteToken(token);
+    }
+}

--- a/DataGateOpenVpnManager.Tests/Services/OpenVpnEvent/OpenVpnEventServiceTests.cs
+++ b/DataGateOpenVpnManager.Tests/Services/OpenVpnEvent/OpenVpnEventServiceTests.cs
@@ -1,0 +1,12 @@
+using DataGateOpenVpnManager.Services.OpenVpnEvent;
+
+namespace DataGateOpenVpnManager.Tests.Services.OpenVpnEvent;
+
+public class OpenVpnEventServiceTests
+{
+    [Fact]
+    public void Service_CanBeConstructed()
+    {
+        Assert.NotNull(new OpenVpnEventService());
+    }
+}

--- a/DataGateOpenVpnManager.Tests/Services/OpenVpnTelnet/CommandQueueConcurrencyTests.cs
+++ b/DataGateOpenVpnManager.Tests/Services/OpenVpnTelnet/CommandQueueConcurrencyTests.cs
@@ -105,6 +105,25 @@ public class CommandQueueConcurrencyTests
             Assert.Contains($"client-{i}", results[i]);
     }
 
+    [Fact]
+    public async Task SendCommandAsync_LateResponseAfterTimeout_DoesNotPoisonNextCommand()
+    {
+        var telnet = new FakeTelnetClient();
+        var queue = new CommandQueue(telnet, Mock.Of<ILogger<CommandQueue>>());
+
+        await Assert.ThrowsAsync<TimeoutException>(() =>
+            queue.SendCommandAsync("slow", CancellationToken.None, timeoutMs: 50));
+
+        telnet.SimulateIncomingData("late-response\nEND");
+
+        var second = queue.SendCommandAsync("fast", CancellationToken.None, timeoutMs: 5000);
+        telnet.SimulateIncomingData("expected-response\nEND");
+
+        var result = await second;
+        Assert.Contains("expected-response", result);
+        Assert.DoesNotContain("late-response", result);
+    }
+
     private sealed class ConcurrentTrackingFakeTelnetClient : FakeTelnetClient
     {
         private int _concurrentSends;

--- a/DataGateOpenVpnManager.Tests/Services/OpenVpnTelnet/CommandQueueConcurrencyTests.cs
+++ b/DataGateOpenVpnManager.Tests/Services/OpenVpnTelnet/CommandQueueConcurrencyTests.cs
@@ -1,0 +1,128 @@
+using DataGateOpenVpnManager.Services.OpenVpnTelnet;
+using DataGateOpenVpnManager.Tests.Services.OpenVpnTelnet.Fakes;
+using Microsoft.Extensions.Logging;
+using Moq;
+
+namespace DataGateOpenVpnManager.Tests.Services.OpenVpnTelnet;
+
+public class CommandQueueConcurrencyTests
+{
+    /// <summary>
+    /// Documents false "client not in management": overlapping waiters get responses FIFO,
+    /// so the first caller may receive a snapshot that does not contain its peer yet.
+    /// </summary>
+    [Fact]
+    public async Task FifoResponseMatching_WithOverlappingCommands_FirstWaiterCanGetWrongSnapshot()
+    {
+        var pending = new Queue<TaskCompletionSource<string>>();
+
+        Task<string> SendCommand()
+        {
+            var tcs = new TaskCompletionSource<string>(TaskCreationOptions.RunContinuationsAsynchronously);
+            pending.Enqueue(tcs);
+            return tcs.Task;
+        }
+
+        void Receive(string payload)
+        {
+            if (pending.TryDequeue(out var tcs))
+                tcs.TrySetResult(payload);
+        }
+
+        var byteDebugSnapshot = SendCommand();
+        var zombieSnapshot = SendCommand();
+
+        Receive("CLIENT_LIST\tstatusgate\t127.0.0.1:11111\t10.51.16.2\nEND");
+        Receive("CLIENT_LIST\tadg-77\t127.0.0.1:55059\t10.51.16.3\nEND");
+
+        var firstResult = await byteDebugSnapshot;
+        var secondResult = await zombieSnapshot;
+
+        Assert.Contains("statusgate", firstResult);
+        Assert.DoesNotContain("55059", firstResult);
+        Assert.Contains("adg-77", secondResult);
+        Assert.Contains("55059", secondResult);
+    }
+
+    [Fact]
+    public async Task SendCommandAsync_ConcurrentCommands_ExecutesAtMostOneSendAtATime()
+    {
+        var telnet = new ConcurrentTrackingFakeTelnetClient();
+        var queue = new CommandQueue(telnet, Mock.Of<ILogger<CommandQueue>>());
+        const int commandCount = 40;
+
+        var responder = Task.Run(async () =>
+        {
+            for (var i = 0; i < commandCount; i++)
+            {
+                while (telnet.SentCommands.Count <= i)
+                    await Task.Delay(1);
+
+                telnet.SimulateIncomingData($"marker-{i}\nEND");
+            }
+        });
+
+        var commands = Enumerable.Range(0, commandCount)
+            .Select(i => queue.SendCommandAsync($"status-{i}", CancellationToken.None, timeoutMs: 5000))
+            .ToArray();
+
+        var results = await Task.WhenAll(commands);
+        await responder;
+
+        Assert.Equal(1, telnet.MaxConcurrentSends);
+        Assert.Equal(commandCount, telnet.SentCommands.Count);
+        for (var i = 0; i < commandCount; i++)
+            Assert.Contains($"marker-{i}", results[i]);
+    }
+
+    [Fact]
+    public async Task SendCommandAsync_ConcurrentStatus3LikeWorkload_EachCallerGetsItsOwnResponse()
+    {
+        var telnet = new ConcurrentTrackingFakeTelnetClient();
+        var queue = new CommandQueue(telnet, Mock.Of<ILogger<CommandQueue>>());
+        const int commandCount = 20;
+
+        var responder = Task.Run(async () =>
+        {
+            for (var i = 0; i < commandCount; i++)
+            {
+                while (telnet.SentCommands.Count <= i)
+                    await Task.Delay(1);
+
+                telnet.SimulateIncomingData(
+                    $"CLIENT_LIST\tclient-{i}\t127.0.0.1:{50000 + i}\t10.51.16.{i + 2}\nEND");
+            }
+        });
+
+        var tasks = Enumerable.Range(0, commandCount)
+            .Select(_ => queue.SendCommandAsync("status 3", CancellationToken.None, timeoutMs: 5000))
+            .ToArray();
+
+        var results = await Task.WhenAll(tasks);
+        await responder;
+
+        for (var i = 0; i < commandCount; i++)
+            Assert.Contains($"client-{i}", results[i]);
+    }
+
+    private sealed class ConcurrentTrackingFakeTelnetClient : FakeTelnetClient
+    {
+        private int _concurrentSends;
+
+        public int MaxConcurrentSends { get; private set; }
+
+        public override Task SendAsync(string command, CancellationToken cancellationToken)
+        {
+            var inFlight = Interlocked.Increment(ref _concurrentSends);
+            MaxConcurrentSends = Math.Max(MaxConcurrentSends, inFlight);
+            try
+            {
+                return base.SendAsync(command, cancellationToken);
+            }
+            finally
+            {
+                Interlocked.Decrement(ref _concurrentSends);
+            }
+        }
+    }
+}

--- a/DataGateOpenVpnManager.Tests/Services/OpenVpnTelnet/MessageSubscriberTests.cs
+++ b/DataGateOpenVpnManager.Tests/Services/OpenVpnTelnet/MessageSubscriberTests.cs
@@ -1,0 +1,46 @@
+using DataGateOpenVpnManager.Hubs;
+using DataGateOpenVpnManager.Services.OpenVpnEvent.Subscribers;
+using DataGateOpenVpnManager.Services.OpenVpnTelnet.Subscribers;
+using Microsoft.AspNetCore.SignalR;
+using Moq;
+
+namespace DataGateOpenVpnManager.Tests.Services.OpenVpnTelnet;
+
+public class MessageSubscriberTests
+{
+    [Fact]
+    public async Task SignalRMessageSubscriber_ForwardsMessageToCaller()
+    {
+        var clientProxy = new Mock<ISingleClientProxy>();
+        clientProxy.Setup(c => c.SendCoreAsync("ReceiveMessage", It.IsAny<object?[]>(), It.IsAny<CancellationToken>()))
+            .Returns(Task.CompletedTask);
+
+        var clients = new Mock<IHubClients>();
+        clients.Setup(c => c.Client("conn-1")).Returns(clientProxy.Object);
+        var hubContext = new Mock<IHubContext<OpenVpnSignalHub>>();
+        hubContext.Setup(h => h.Clients).Returns(clients.Object);
+
+        var subscriber = new SignalRMessageSubscriber(hubContext.Object, "conn-1");
+        await subscriber.OnMessageReceived("CLIENT_LIST\nEND", CancellationToken.None);
+
+        clientProxy.Verify(c => c.SendCoreAsync("ReceiveMessage", It.IsAny<object?[]>(), It.IsAny<CancellationToken>()), Times.Once);
+    }
+
+    [Fact]
+    public async Task OpenVpnEventsMessageSubscriber_ForwardsMessageToCaller()
+    {
+        var clientProxy = new Mock<ISingleClientProxy>();
+        clientProxy.Setup(c => c.SendCoreAsync("ReceiveEventMessage", It.IsAny<object?[]>(), It.IsAny<CancellationToken>()))
+            .Returns(Task.CompletedTask);
+
+        var clients = new Mock<IHubClients>();
+        clients.Setup(c => c.Client("conn-2")).Returns(clientProxy.Object);
+        var hubContext = new Mock<IHubContext<OpenVpnEventHub>>();
+        hubContext.Setup(h => h.Clients).Returns(clients.Object);
+
+        var subscriber = new OpenVpnEventsMessageSubscriber(hubContext.Object, "conn-2");
+        await subscriber.OnMessageReceived("event payload", CancellationToken.None);
+
+        clientProxy.Verify(c => c.SendCoreAsync("ReceiveEventMessage", It.IsAny<object?[]>(), It.IsAny<CancellationToken>()), Times.Once);
+    }
+}

--- a/DataGateOpenVpnManager.Tests/Services/Proxy/NoOpProxySessionAuditService.cs
+++ b/DataGateOpenVpnManager.Tests/Services/Proxy/NoOpProxySessionAuditService.cs
@@ -1,0 +1,11 @@
+namespace DataGateOpenVpnManager.Tests.Services.Proxy;
+
+public sealed class NoOpProxySessionAuditService : DataGateOpenVpnManager.Services.Proxy.IProxySessionAuditService
+{
+    public void Record(DataGateOpenVpnManager.Services.Proxy.ProxySessionAuditEntry entry)
+    {
+    }
+
+    public IReadOnlyList<DataGateOpenVpnManager.Services.Proxy.ProxySessionAuditEntry> GetRecent(int limit) =>
+        Array.Empty<DataGateOpenVpnManager.Services.Proxy.ProxySessionAuditEntry>();
+}

--- a/DataGateOpenVpnManager.Tests/Services/Proxy/OpenVpnManagementStatusCacheConcurrencyTests.cs
+++ b/DataGateOpenVpnManager.Tests/Services/Proxy/OpenVpnManagementStatusCacheConcurrencyTests.cs
@@ -1,0 +1,133 @@
+using DataGateOpenVpnManager.Models;
+using DataGateOpenVpnManager.Services.OpenVpnTelnet;
+using DataGateOpenVpnManager.Services.Proxy;
+using DataGateOpenVpnManager.Tests.Services.OpenVpnTelnet.Fakes;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+using Moq;
+
+namespace DataGateOpenVpnManager.Tests.Services.Proxy;
+
+public class OpenVpnManagementStatusCacheConcurrencyTests
+{
+    [Fact]
+    public async Task RefreshAsync_ConcurrentCalls_ExecutesSingleManagementQueryAtATime()
+    {
+        var telnet = new ConcurrentTrackingFakeTelnetClient();
+        var management = new OpenVpnManagementSignalService(telnet, Mock.Of<ILogger<CommandQueue>>());
+        var cache = new OpenVpnManagementStatusCache(management, new NoOpProxySessionAuditService(), Mock.Of<ILogger<OpenVpnManagementStatusCache>>());
+        const int refreshCount = 12;
+
+        var responder = Task.Run(async () =>
+        {
+            for (var i = 0; i < refreshCount; i++)
+            {
+                while (telnet.SentCommands.Count <= i)
+                    await Task.Delay(1);
+
+                telnet.SimulateIncomingData(
+                    "CLIENT_LIST\tadg-77\t127.0.0.1:55059\t10.51.16.3\t\t1000\t2000\t1\tUNDEF\nEND");
+            }
+        });
+
+        var refreshTasks = Enumerable.Range(0, refreshCount)
+            .Select(_ => cache.RefreshAsync(CancellationToken.None))
+            .ToArray();
+
+        await Task.WhenAll(refreshTasks);
+        await responder;
+
+        Assert.Equal(1, telnet.MaxConcurrentSends);
+        Assert.Equal(refreshCount, telnet.SentCommands.Count);
+
+        var snapshot = cache.GetSnapshot();
+        Assert.NotNull(snapshot);
+        Assert.True(snapshot!.IsValid);
+        Assert.Single(snapshot.Clients);
+        Assert.Equal("adg-77", snapshot.Clients[0].CommonName);
+    }
+
+    [Fact]
+    public async Task ByteDebugAndZombieMonitors_ReadSameCachedSnapshot_WithoutDirectManagementCalls()
+    {
+        var telnet = new ConcurrentTrackingFakeTelnetClient();
+        var management = new OpenVpnManagementSignalService(telnet, Mock.Of<ILogger<CommandQueue>>());
+        var cache = new OpenVpnManagementStatusCache(management, new NoOpProxySessionAuditService(), Mock.Of<ILogger<OpenVpnManagementStatusCache>>());
+
+        var refreshTask = cache.RefreshAsync(CancellationToken.None);
+        await Task.Delay(20);
+        telnet.SimulateIncomingData("CLIENT_LIST\tadg-77\t127.0.0.1:60123\t10.51.16.3\t\t1000\t2000\t1\tUNDEF\nEND");
+        await refreshTask;
+
+        telnet.SentCommands.Clear();
+
+        var active = new ActiveProxyConnectionService();
+        active.Add(new DataGateMonitor.SharedModels.DataGateOpenVpnManager.Proxy.ActiveProxyConnection
+        {
+            ConnectionId = "conn-1",
+            Protocol = DataGateMonitor.SharedModels.DataGateOpenVpnManager.Proxy.Enums.ProxyConnectionProtocol.Udp,
+            RealClientIp = "203.0.113.1",
+            RealClientPort = 50000,
+            LocalProxyIp = "127.0.0.1",
+            LocalProxyPort = 60123,
+            TargetIp = "127.0.0.1",
+            TargetPort = 1194,
+            ConnectedAtUtc = DateTime.UtcNow
+        });
+
+        var byteDebug = new ProxyByteDebugService(
+            Options.Create(new OpenVpnProxyOptions { ByteDebug = true }),
+            cache,
+            new NoOpProxySessionAuditService(),
+            Mock.Of<ILogger<ProxyByteDebugService>>());
+
+        var zombieMonitor = new ProxyZombieConnectionMonitorService(
+            Options.Create(new OpenVpnProxyOptions { CloseZombieAfterMissingSeconds = 90 }),
+            active,
+            new ProxyConnectionLifetimeService(new NoOpProxySessionAuditService(), Mock.Of<ILogger<ProxyConnectionLifetimeService>>()),
+            cache,
+            new NoOpProxySessionAuditService(),
+            Mock.Of<ILogger<ProxyZombieConnectionMonitorService>>());
+
+        await byteDebug.CompareAndLogAsync(new ProxyTrafficFlowUpdate
+        {
+            ConnectionId = "conn-1",
+            Protocol = DataGateMonitor.SharedModels.DataGateOpenVpnManager.Proxy.Enums.ProxyConnectionProtocol.Udp,
+            State = "connected",
+            IsConnected = true,
+            IsIdle = false,
+            LocalProxyIp = "127.0.0.1",
+            LocalProxyPort = 60123,
+            ClientToServerBytesTotal = 1000,
+            ServerToClientBytesTotal = 2000,
+            ConnectedAtUtc = DateTime.UtcNow,
+            LastActivityAtUtc = DateTime.UtcNow,
+            EmittedAtUtc = DateTime.UtcNow
+        }, "periodic", CancellationToken.None);
+
+        zombieMonitor.CheckActiveConnections();
+
+        Assert.Empty(telnet.SentCommands);
+    }
+
+    private sealed class ConcurrentTrackingFakeTelnetClient : FakeTelnetClient
+    {
+        private int _concurrentSends;
+
+        public int MaxConcurrentSends { get; private set; }
+
+        public override Task SendAsync(string command, CancellationToken cancellationToken)
+        {
+            var inFlight = Interlocked.Increment(ref _concurrentSends);
+            MaxConcurrentSends = Math.Max(MaxConcurrentSends, inFlight);
+            try
+            {
+                return base.SendAsync(command, cancellationToken);
+            }
+            finally
+            {
+                Interlocked.Decrement(ref _concurrentSends);
+            }
+        }
+    }
+}

--- a/DataGateOpenVpnManager.Tests/Services/Proxy/OpenVpnManagementStatusParserTests.cs
+++ b/DataGateOpenVpnManager.Tests/Services/Proxy/OpenVpnManagementStatusParserTests.cs
@@ -1,0 +1,63 @@
+using DataGateOpenVpnManager.Services.Proxy;
+
+namespace DataGateOpenVpnManager.Tests.Services.Proxy;
+
+public class OpenVpnManagementStatusParserTests
+{
+    private const string SampleStatus =
+        """
+        TITLE	OpenVPN 2.6.12
+        TIME	Thu Jun 19 12:00:00 2026	1748337600
+        CLIENT_LIST	adg-77	127.0.0.1:54321	10.51.16.3		1234567	9876543	1748337500	UNDEF
+        CLIENT_LIST	other	198.51.100.20:1194	10.51.16.4		100	200	1748337500	UNDEF
+        ROUTING_TABLE
+        GLOBAL_STATS
+        END
+        """;
+
+    [Fact]
+    public void ParseClientList_ParsesStatus3Rows()
+    {
+        var clients = OpenVpnManagementStatusParser.ParseClientList(SampleStatus);
+        Assert.Equal(2, clients.Count);
+
+        var first = clients[0];
+        Assert.Equal("adg-77", first.CommonName);
+        Assert.Equal("127.0.0.1:54321", first.RealAddress);
+        Assert.Equal("10.51.16.3", first.VirtualAddress);
+        Assert.Equal(1_234_567, first.BytesReceived);
+        Assert.Equal(9_876_543, first.BytesSent);
+    }
+
+    [Fact]
+    public void FindByLocalProxyPort_MatchesLoopbackClient()
+    {
+        var clients = OpenVpnManagementStatusParser.ParseClientList(SampleStatus);
+        var match = OpenVpnManagementStatusParser.FindByLocalProxyPort(clients, "127.0.0.1", 54321);
+
+        Assert.NotNull(match);
+        Assert.Equal("adg-77", match!.CommonName);
+    }
+
+    [Theory]
+    [InlineData("localhost", "127.0.0.1", 54321)]
+    [InlineData("127.0.0.1", "localhost", 54321)]
+    public void FindByLocalProxyPort_TreatsLoopbackHostsAsEqual(string localIp, string realAddressIp, int port)
+    {
+        var status =
+            $"CLIENT_LIST	test	{realAddressIp}:{port}	10.51.16.3		10	20	1748337500	UNDEF\n";
+        var clients = OpenVpnManagementStatusParser.ParseClientList(status);
+        var match = OpenVpnManagementStatusParser.FindByLocalProxyPort(clients, localIp, port);
+        Assert.NotNull(match);
+    }
+
+    [Fact]
+    public void ProxyByteComparison_ComputesDeltas()
+    {
+        var comparison = ProxyByteComparison.Create(1_000, 2_000, 950, 2_100);
+        Assert.Equal(50, comparison.DeltaClientToServer);
+        Assert.Equal(-100, comparison.DeltaServerToClient);
+        Assert.True(comparison.HasMaterialDelta(50));
+        Assert.False(comparison.HasMaterialDelta(101));
+    }
+}

--- a/DataGateOpenVpnManager.Tests/Services/Proxy/OpenVpnManagementStatusRefreshServiceTests.cs
+++ b/DataGateOpenVpnManager.Tests/Services/Proxy/OpenVpnManagementStatusRefreshServiceTests.cs
@@ -1,0 +1,61 @@
+using DataGateOpenVpnManager.Models;
+using DataGateOpenVpnManager.Services.OpenVpnTelnet;
+using DataGateOpenVpnManager.Services.Proxy;
+using DataGateOpenVpnManager.Tests.Services.OpenVpnTelnet.Fakes;
+using Microsoft.Extensions.Logging.Abstractions;
+using Microsoft.Extensions.Options;
+
+namespace DataGateOpenVpnManager.Tests.Services.Proxy;
+
+public class OpenVpnManagementStatusRefreshServiceTests
+{
+    [Fact]
+    public async Task ExecuteAsync_WhenRefreshDisabled_IdlesWithoutCallingManagement()
+    {
+        var telnet = new FakeTelnetClient();
+        var management = new OpenVpnManagementSignalService(telnet, NullLogger<CommandQueue>.Instance);
+        var cache = new OpenVpnManagementStatusCache(management, new NoOpProxySessionAuditService(), NullLogger<OpenVpnManagementStatusCache>.Instance);
+        var service = new OpenVpnManagementStatusRefreshService(
+            Options.Create(new OpenVpnProxyOptions()),
+            cache,
+            NullLogger<OpenVpnManagementStatusRefreshService>.Instance);
+
+        await service.StartAsync(CancellationToken.None);
+        await Task.Delay(150);
+        await service.StopAsync(CancellationToken.None);
+
+        Assert.Empty(telnet.SentCommands);
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_WhenZombieEnabled_RefreshesManagement()
+    {
+        var telnet = new AutoRespondingFakeTelnetClient("END");
+        var management = new OpenVpnManagementSignalService(telnet, NullLogger<CommandQueue>.Instance);
+        var cache = new OpenVpnManagementStatusCache(management, new NoOpProxySessionAuditService(), NullLogger<OpenVpnManagementStatusCache>.Instance);
+        var service = new OpenVpnManagementStatusRefreshService(
+            Options.Create(new OpenVpnProxyOptions
+            {
+                CloseZombieAfterMissingSeconds = 60,
+                ManagementStatusRefreshSeconds = 1
+            }),
+            cache,
+            NullLogger<OpenVpnManagementStatusRefreshService>.Instance);
+
+        await service.StartAsync(CancellationToken.None);
+        await Task.Delay(1200);
+        await service.StopAsync(CancellationToken.None);
+
+        Assert.Contains("status 3", telnet.SentCommands);
+    }
+
+    private sealed class AutoRespondingFakeTelnetClient(string response) : FakeTelnetClient
+    {
+        public override Task SendAsync(string command, CancellationToken cancellationToken)
+        {
+            var task = base.SendAsync(command, cancellationToken);
+            SimulateIncomingData(response);
+            return task;
+        }
+    }
+}

--- a/DataGateOpenVpnManager.Tests/Services/Proxy/ProxyAuditDetailsTests.cs
+++ b/DataGateOpenVpnManager.Tests/Services/Proxy/ProxyAuditDetailsTests.cs
@@ -1,0 +1,53 @@
+using DataGateOpenVpnManager.Services.Proxy;
+using DataGateMonitor.SharedModels.DataGateOpenVpnManager.Proxy;
+using DataGateMonitor.SharedModels.DataGateOpenVpnManager.Proxy.Enums;
+
+namespace DataGateOpenVpnManager.Tests.Services.Proxy;
+
+public class ProxyAuditDetailsTests
+{
+    [Fact]
+    public void ForConnection_IncludesLocalAndClientEndpoints()
+    {
+        var details = ProxyAuditDetails.ForConnection(new ActiveProxyConnection
+        {
+            ConnectionId = "c1",
+            Protocol = ProxyConnectionProtocol.Tcp,
+            RealClientIp = "203.0.113.1",
+            RealClientPort = 50000,
+            LocalProxyIp = "127.0.0.1",
+            LocalProxyPort = 60123,
+            TargetIp = "127.0.0.1",
+            TargetPort = 1194,
+            ConnectedAtUtc = new DateTime(2026, 6, 19, 12, 0, 0, DateTimeKind.Utc)
+        });
+
+        Assert.Equal("Tcp", details["proto"]);
+        Assert.Equal("127.0.0.1:60123", details["local"]);
+        Assert.Equal("203.0.113.1:50000", details["client"]);
+        Assert.Contains("2026-06-19T12:00:00", details["connectedAtUtc"]);
+    }
+
+    [Fact]
+    public void ForSnapshot_ReturnsNullMarker_WhenSnapshotMissing()
+    {
+        var details = ProxyAuditDetails.ForSnapshot(null);
+        Assert.Equal("null", details["cache"]);
+    }
+
+    [Fact]
+    public void ForSnapshot_IncludesClientCountAndAge()
+    {
+        var fetchedAt = DateTime.UtcNow.AddSeconds(-10);
+        var snapshot = new OpenVpnManagementStatusSnapshot(
+            fetchedAt,
+            "END",
+            [new OpenVpnManagementClientEntry("cn", "127.0.0.1:1", "10.0.0.2", 1, 2, 3)],
+            IsValid: true);
+
+        var details = ProxyAuditDetails.ForSnapshot(snapshot);
+
+        Assert.Equal("1", details["mgmtClientCount"]);
+        Assert.True(double.Parse(details["cacheAgeSec"]) >= 9);
+    }
+}

--- a/DataGateOpenVpnManager.Tests/Services/Proxy/ProxyByteComparisonTests.cs
+++ b/DataGateOpenVpnManager.Tests/Services/Proxy/ProxyByteComparisonTests.cs
@@ -1,0 +1,14 @@
+using DataGateOpenVpnManager.Services.Proxy;
+
+namespace DataGateOpenVpnManager.Tests.Services.Proxy;
+
+public class ProxyByteComparisonTests
+{
+    [Fact]
+    public void HasMaterialDelta_WhenAnyDirectionExceedsThreshold()
+    {
+        var comparison = ProxyByteComparison.Create(10_000, 100, 5_000, 100);
+        Assert.True(comparison.HasMaterialDelta(4096));
+        Assert.False(comparison.HasMaterialDelta(10_000));
+    }
+}

--- a/DataGateOpenVpnManager.Tests/Services/Proxy/ProxyByteDebugMonitorServiceTests.cs
+++ b/DataGateOpenVpnManager.Tests/Services/Proxy/ProxyByteDebugMonitorServiceTests.cs
@@ -1,0 +1,73 @@
+using DataGateOpenVpnManager.Models;
+using DataGateOpenVpnManager.Services.OpenVpnTelnet;
+using DataGateOpenVpnManager.Services.Proxy;
+using DataGateMonitor.SharedModels.DataGateOpenVpnManager.Proxy;
+using DataGateMonitor.SharedModels.DataGateOpenVpnManager.Proxy.Enums;
+using Microsoft.Extensions.Logging.Abstractions;
+using Microsoft.Extensions.Options;
+
+namespace DataGateOpenVpnManager.Tests.Services.Proxy;
+
+public class ProxyByteDebugMonitorServiceTests
+{
+    [Fact]
+    public async Task ExecuteAsync_WhenDisabled_IdlesWithoutThrowing()
+    {
+        var service = CreateService(new OpenVpnProxyOptions());
+        await service.StartAsync(CancellationToken.None);
+        await Task.Delay(150);
+        await service.StopAsync(CancellationToken.None);
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_WhenEnabled_ComparesActiveConnections()
+    {
+        var active = new ActiveProxyConnectionService();
+        var connection = new ActiveProxyConnection
+        {
+            ConnectionId = "c1",
+            Protocol = ProxyConnectionProtocol.Udp,
+            RealClientIp = "203.0.113.1",
+            RealClientPort = 50000,
+            LocalProxyIp = "127.0.0.1",
+            LocalProxyPort = 60123,
+            TargetIp = "127.0.0.1",
+            TargetPort = 1194,
+            ConnectedAtUtc = DateTime.UtcNow
+        };
+        active.Add(connection);
+
+        var flow = new ProxyTrafficFlowService();
+        flow.RegisterConnection(connection);
+        flow.RecordTraffic("c1", ProxyTrafficFlowDirection.ClientToServer, 128);
+
+        var byteDebug = new ProxyByteDebugService(
+            Options.Create(new OpenVpnProxyOptions { ByteDebug = true }),
+            new OpenVpnManagementStatusCache(null!, new NoOpProxySessionAuditService(), NullLogger<OpenVpnManagementStatusCache>.Instance),
+            new NoOpProxySessionAuditService(),
+            NullLogger<ProxyByteDebugService>.Instance);
+
+        var service = new ProxyByteDebugMonitorService(
+            Options.Create(new OpenVpnProxyOptions { ByteDebug = true, ByteDebugIntervalSeconds = 1 }),
+            active,
+            flow,
+            byteDebug,
+            NullLogger<ProxyByteDebugMonitorService>.Instance);
+
+        await service.StartAsync(CancellationToken.None);
+        await Task.Delay(1300);
+        await service.StopAsync(CancellationToken.None);
+    }
+
+    private static ProxyByteDebugMonitorService CreateService(OpenVpnProxyOptions options) =>
+        new(
+            Options.Create(options),
+            new ActiveProxyConnectionService(),
+            new ProxyTrafficFlowService(),
+            new ProxyByteDebugService(
+                Options.Create(options),
+                new OpenVpnManagementStatusCache(null!, new NoOpProxySessionAuditService(), NullLogger<OpenVpnManagementStatusCache>.Instance),
+                new NoOpProxySessionAuditService(),
+                NullLogger<ProxyByteDebugService>.Instance),
+            NullLogger<ProxyByteDebugMonitorService>.Instance);
+}

--- a/DataGateOpenVpnManager.Tests/Services/Proxy/ProxyByteDebugServiceTests.cs
+++ b/DataGateOpenVpnManager.Tests/Services/Proxy/ProxyByteDebugServiceTests.cs
@@ -44,7 +44,7 @@ public class ProxyByteDebugServiceTests
             ConnectedAtUtc = DateTime.UtcNow,
             LastActivityAtUtc = DateTime.UtcNow,
             EmittedAtUtc = DateTime.UtcNow
-        }, "disconnect", CancellationToken.None);
+        }, "periodic", CancellationToken.None);
 
         logger.Verify(
             x => x.Log(

--- a/DataGateOpenVpnManager.Tests/Services/Proxy/ProxyByteDebugServiceTests.cs
+++ b/DataGateOpenVpnManager.Tests/Services/Proxy/ProxyByteDebugServiceTests.cs
@@ -1,0 +1,83 @@
+using DataGateOpenVpnManager.Models;
+using DataGateOpenVpnManager.Services.Proxy;
+using DataGateMonitor.SharedModels.DataGateOpenVpnManager.Proxy.Enums;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+using Moq;
+
+namespace DataGateOpenVpnManager.Tests.Services.Proxy;
+
+public class ProxyByteDebugServiceTests
+{
+    [Fact]
+    public async Task CompareAndLogAsync_LogsComparison_WhenManagementClientFound()
+    {
+        var telnet = new DataGateOpenVpnManager.Tests.Services.OpenVpnTelnet.Fakes.FakeTelnetClient();
+        var management = new DataGateOpenVpnManager.Services.OpenVpnTelnet.OpenVpnManagementSignalService(
+            telnet,
+            Mock.Of<ILogger<DataGateOpenVpnManager.Services.OpenVpnTelnet.CommandQueue>>());
+        var realCache = new OpenVpnManagementStatusCache(management, new NoOpProxySessionAuditService(), Mock.Of<ILogger<OpenVpnManagementStatusCache>>());
+        var refreshTask = realCache.RefreshAsync(CancellationToken.None);
+        await Task.Delay(50);
+        telnet.SimulateIncomingData(
+            "CLIENT_LIST\tadg-77\t127.0.0.1:60123\t10.51.16.3\t\t1000\t2000\t1748337500\tUNDEF\nEND\n");
+        await refreshTask;
+
+        var logger = new Mock<ILogger<ProxyByteDebugService>>();
+        var service = new ProxyByteDebugService(
+            Options.Create(new OpenVpnProxyOptions { ByteDebug = true, ByteDebugWarnDeltaBytes = 4096 }),
+            realCache,
+            new NoOpProxySessionAuditService(),
+            logger.Object);
+
+        await service.CompareAndLogAsync(new ProxyTrafficFlowUpdate
+        {
+            ConnectionId = "conn-1",
+            Protocol = ProxyConnectionProtocol.Udp,
+            State = "disconnected",
+            IsConnected = false,
+            IsIdle = true,
+            LocalProxyIp = "127.0.0.1",
+            LocalProxyPort = 60123,
+            ClientToServerBytesTotal = 1000,
+            ServerToClientBytesTotal = 2000,
+            ConnectedAtUtc = DateTime.UtcNow,
+            LastActivityAtUtc = DateTime.UtcNow,
+            EmittedAtUtc = DateTime.UtcNow
+        }, "disconnect", CancellationToken.None);
+
+        logger.Verify(
+            x => x.Log(
+                LogLevel.Information,
+                It.IsAny<EventId>(),
+                It.Is<It.IsAnyType>((state, _) => state.ToString()!.Contains("[ProxyByteDebug]")),
+                It.IsAny<Exception?>(),
+                It.IsAny<Func<It.IsAnyType, Exception?, string>>()),
+            Times.Once);
+    }
+
+    [Fact]
+    public void ReportDisconnect_NoOp_WhenByteDebugDisabled()
+    {
+        var cache = new OpenVpnManagementStatusCache(null!, new NoOpProxySessionAuditService(), Mock.Of<ILogger<OpenVpnManagementStatusCache>>());
+        var service = new ProxyByteDebugService(
+            Options.Create(new OpenVpnProxyOptions { ByteDebug = false }),
+            cache,
+            new NoOpProxySessionAuditService(),
+            Mock.Of<ILogger<ProxyByteDebugService>>());
+
+        service.ReportDisconnect(new ProxyTrafficFlowUpdate
+        {
+            ConnectionId = "conn-1",
+            Protocol = ProxyConnectionProtocol.Tcp,
+            State = "disconnected",
+            IsConnected = false,
+            IsIdle = true,
+            LocalProxyIp = "127.0.0.1",
+            LocalProxyPort = 60123,
+            ConnectedAtUtc = DateTime.UtcNow,
+            LastActivityAtUtc = DateTime.UtcNow,
+            EmittedAtUtc = DateTime.UtcNow
+        });
+    }
+}

--- a/DataGateOpenVpnManager.Tests/Services/Proxy/ProxyConnectionLifetimeServiceTests.cs
+++ b/DataGateOpenVpnManager.Tests/Services/Proxy/ProxyConnectionLifetimeServiceTests.cs
@@ -1,0 +1,36 @@
+using DataGateOpenVpnManager.Services.Proxy;
+using Microsoft.Extensions.Logging.Abstractions;
+
+namespace DataGateOpenVpnManager.Tests.Services.Proxy;
+
+public class ProxyConnectionLifetimeServiceTests
+{
+    [Fact]
+    public void Register_Unregister_ManagesConnections()
+    {
+        var service = new ProxyConnectionLifetimeService(new NoOpProxySessionAuditService(), NullLogger<ProxyConnectionLifetimeService>.Instance);
+        using var cts = new CancellationTokenSource();
+
+        service.Register("conn-1", cts);
+        service.Unregister("conn-1");
+
+        Assert.False(service.TryTerminate("conn-1", "missing"));
+    }
+
+    [Fact]
+    public void TryTerminate_RecordsAuditAndCancelsToken()
+    {
+        var audit = new ProxySessionAuditService(
+            Microsoft.Extensions.Options.Options.Create(new DataGateOpenVpnManager.Models.OpenVpnProxyOptions { SessionAudit = true }),
+            NullLogger<ProxySessionAuditService>.Instance);
+        var service = new ProxyConnectionLifetimeService(audit, NullLogger<ProxyConnectionLifetimeService>.Instance);
+        using var cts = new CancellationTokenSource();
+        service.Register("conn-1", cts);
+
+        Assert.True(service.TryTerminate("conn-1", "zombie"));
+        Assert.True(cts.IsCancellationRequested);
+
+        var recent = audit.GetRecent(10);
+        Assert.Contains(recent, e => e.Event == "proxy.terminated");
+    }
+}

--- a/DataGateOpenVpnManager.Tests/Services/Proxy/ProxyManagementPeerDiagnosticsTests.cs
+++ b/DataGateOpenVpnManager.Tests/Services/Proxy/ProxyManagementPeerDiagnosticsTests.cs
@@ -1,0 +1,45 @@
+using DataGateMonitor.SharedModels.DataGateOpenVpnManager.Proxy;
+using DataGateOpenVpnManager.Models;
+using DataGateOpenVpnManager.Services.Proxy;
+using DataGateMonitor.SharedModels.DataGateOpenVpnManager.Proxy.Enums;
+
+namespace DataGateOpenVpnManager.Tests.Services.Proxy;
+
+public class ProxyManagementPeerDiagnosticsTests
+{
+    [Fact]
+    public void CanEvaluatePeerPresence_ReturnsFalse_WhenCacheEmpty()
+    {
+        var canEvaluate = ProxyManagementPeerDiagnostics.CanEvaluatePeerPresence(
+            null,
+            new OpenVpnProxyOptions { ManagementStatusRefreshSeconds = 30 },
+            out var skipReason);
+
+        Assert.False(canEvaluate);
+        Assert.Equal("management_cache_unavailable", skipReason);
+    }
+
+    [Fact]
+    public void IsLikelyZombie_ReturnsFalse_WhenCacheOlderThanConnection()
+    {
+        var snapshot = new OpenVpnManagementStatusSnapshot(
+            DateTime.UtcNow.AddMinutes(-1),
+            "END",
+            Array.Empty<OpenVpnManagementClientEntry>(),
+            IsValid: true);
+        var connection = new ActiveProxyConnection
+        {
+            ConnectionId = "c1",
+            Protocol = ProxyConnectionProtocol.Udp,
+            RealClientIp = "127.0.0.1",
+            RealClientPort = 1,
+            LocalProxyIp = "127.0.0.1",
+            LocalProxyPort = 60123,
+            TargetIp = "127.0.0.1",
+            TargetPort = 1194,
+            ConnectedAtUtc = DateTime.UtcNow
+        };
+
+        Assert.False(ProxyManagementPeerDiagnostics.IsLikelyZombie(connection, null, snapshot));
+    }
+}

--- a/DataGateOpenVpnManager.Tests/Services/Proxy/ProxySessionAuditServiceTests.cs
+++ b/DataGateOpenVpnManager.Tests/Services/Proxy/ProxySessionAuditServiceTests.cs
@@ -1,0 +1,50 @@
+using DataGateOpenVpnManager.Models;
+using DataGateOpenVpnManager.Services.Proxy;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+using Moq;
+
+namespace DataGateOpenVpnManager.Tests.Services.Proxy;
+
+public class ProxySessionAuditServiceTests
+{
+    [Fact]
+    public void Record_WritesToBuffer_WhenSessionAuditEnabled()
+    {
+        var logger = new Mock<ILogger<ProxySessionAuditService>>();
+        var service = new ProxySessionAuditService(
+            Options.Create(new OpenVpnProxyOptions { SessionAudit = true, SessionAuditBufferSize = 10 }),
+            logger.Object);
+
+        service.Record(new ProxySessionAuditEntry
+        {
+            AtUtc = DateTime.UtcNow,
+            Event = "test.event",
+            ConnectionId = "conn-1",
+            Decision = "ok",
+            Reason = "unit-test"
+        });
+
+        var recent = service.GetRecent(5);
+        Assert.Single(recent);
+        Assert.Equal("test.event", recent[0].Event);
+    }
+
+    [Fact]
+    public void Record_IsNoOp_WhenSessionAuditDisabled()
+    {
+        var service = new ProxySessionAuditService(
+            Options.Create(new OpenVpnProxyOptions { SessionAudit = false, ByteDebug = false }),
+            Mock.Of<ILogger<ProxySessionAuditService>>());
+
+        service.Record(new ProxySessionAuditEntry
+        {
+            AtUtc = DateTime.UtcNow,
+            Event = "test.event",
+            Decision = "ok",
+            Reason = "unit-test"
+        });
+
+        Assert.Empty(service.GetRecent(5));
+    }
+}

--- a/DataGateOpenVpnManager.Tests/Services/Proxy/ProxyTrafficFlowBroadcastServiceTests.cs
+++ b/DataGateOpenVpnManager.Tests/Services/Proxy/ProxyTrafficFlowBroadcastServiceTests.cs
@@ -1,0 +1,51 @@
+using DataGateOpenVpnManager.Hubs;
+using DataGateOpenVpnManager.Services.Proxy;
+using DataGateMonitor.SharedModels.DataGateOpenVpnManager.Proxy.Enums;
+using Microsoft.AspNetCore.SignalR;
+using Microsoft.Extensions.Logging.Abstractions;
+using Moq;
+
+namespace DataGateOpenVpnManager.Tests.Services.Proxy;
+
+public class ProxyTrafficFlowBroadcastServiceTests
+{
+    [Fact]
+    public async Task ExecuteAsync_BroadcastsBatch_WhenFlowHasUpdates()
+    {
+        var flow = new ProxyTrafficFlowService();
+        flow.RegisterConnectFailed(
+            "failed-1",
+            ProxyConnectionProtocol.Tcp,
+            "203.0.113.1",
+            50000,
+            null,
+            "127.0.0.1",
+            1194,
+            "boom");
+
+        var clientProxy = new Mock<IClientProxy>();
+        clientProxy.Setup(c => c.SendCoreAsync(
+                "TrafficFlowUpdated",
+                It.IsAny<object?[]>(),
+                It.IsAny<CancellationToken>()))
+            .Returns(Task.CompletedTask);
+
+        var clients = new Mock<IHubClients>();
+        clients.Setup(c => c.All).Returns(clientProxy.Object);
+        var hubContext = new Mock<IHubContext<ProxyTrafficFlowHub>>();
+        hubContext.Setup(h => h.Clients).Returns(clients.Object);
+
+        var service = new ProxyTrafficFlowBroadcastService(
+            flow,
+            hubContext.Object,
+            NullLogger<ProxyTrafficFlowBroadcastService>.Instance);
+
+        await service.StartAsync(CancellationToken.None);
+        await Task.Delay(1200);
+        await service.StopAsync(CancellationToken.None);
+
+        clientProxy.Verify(
+            c => c.SendCoreAsync("TrafficFlowUpdated", It.IsAny<object?[]>(), It.IsAny<CancellationToken>()),
+            Times.AtLeastOnce);
+    }
+}

--- a/DataGateOpenVpnManager.Tests/Services/Proxy/ProxyTrafficFlowServiceTests.cs
+++ b/DataGateOpenVpnManager.Tests/Services/Proxy/ProxyTrafficFlowServiceTests.cs
@@ -237,4 +237,30 @@ public class ProxyTrafficFlowServiceTests
         Assert.Equal("alice", update.Username);
         Assert.Equal("alice@example.com", update.Email);
     }
+
+    [Fact]
+    public void TryGetTotals_ReturnsCurrentTotals_ForActiveConnection()
+    {
+        var service = new ProxyTrafficFlowService();
+        var connectedAt = new DateTime(2026, 05, 08, 12, 0, 0, DateTimeKind.Utc);
+        service.RegisterConnection(new ActiveProxyConnection
+        {
+            ConnectionId = "conn-5",
+            Protocol = ProxyConnectionProtocol.Tcp,
+            RealClientIp = "198.18.0.9",
+            RealClientPort = 53000,
+            LocalProxyIp = "127.0.0.1",
+            LocalProxyPort = 60300,
+            TargetIp = "127.0.0.1",
+            TargetPort = 1194,
+            ConnectedAtUtc = connectedAt
+        });
+
+        service.RecordTraffic("conn-5", ProxyTrafficFlowDirection.ClientToServer, 100, connectedAt);
+        service.RecordTraffic("conn-5", ProxyTrafficFlowDirection.ServerToClient, 200, connectedAt);
+
+        Assert.True(service.TryGetTotals("conn-5", out var c2s, out var s2c));
+        Assert.Equal(100, c2s);
+        Assert.Equal(200, s2c);
+    }
 }

--- a/DataGateOpenVpnManager.Tests/Services/Proxy/ProxyZombieConnectionMonitorServiceTests.cs
+++ b/DataGateOpenVpnManager.Tests/Services/Proxy/ProxyZombieConnectionMonitorServiceTests.cs
@@ -1,0 +1,129 @@
+using DataGateOpenVpnManager.Models;
+using DataGateOpenVpnManager.Services.OpenVpnTelnet;
+using DataGateOpenVpnManager.Services.Proxy;
+using DataGateOpenVpnManager.Tests.Services.OpenVpnTelnet.Fakes;
+using DataGateMonitor.SharedModels.DataGateOpenVpnManager.Proxy;
+using DataGateMonitor.SharedModels.DataGateOpenVpnManager.Proxy.Enums;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+using Moq;
+
+namespace DataGateOpenVpnManager.Tests.Services.Proxy;
+
+public class ProxyZombieConnectionMonitorServiceTests
+{
+    [Fact]
+    public async Task CheckActiveConnections_TerminatesConnection_AfterConsecutiveMissesAndDuration()
+    {
+        var active = new ActiveProxyConnectionService();
+        active.Add(new ActiveProxyConnection
+        {
+            ConnectionId = "conn-zombie",
+            Protocol = ProxyConnectionProtocol.Udp,
+            RealClientIp = "203.0.113.1",
+            RealClientPort = 50000,
+            LocalProxyIp = "127.0.0.1",
+            LocalProxyPort = 60123,
+            TargetIp = "127.0.0.1",
+            TargetPort = 1194,
+            ConnectedAtUtc = DateTime.UtcNow.AddMinutes(-5)
+        });
+
+        using var cts = new CancellationTokenSource();
+        var lifetime = new ProxyConnectionLifetimeService(new NoOpProxySessionAuditService(), Mock.Of<ILogger<ProxyConnectionLifetimeService>>());
+        lifetime.Register("conn-zombie", cts);
+
+        var telnet = new FakeTelnetClient();
+        var management = new OpenVpnManagementSignalService(telnet, Mock.Of<ILogger<CommandQueue>>());
+        var cache = new OpenVpnManagementStatusCache(management, new NoOpProxySessionAuditService(), Mock.Of<ILogger<OpenVpnManagementStatusCache>>());
+
+        var monitor = new ProxyZombieConnectionMonitorService(
+            Options.Create(new OpenVpnProxyOptions
+            {
+                CloseZombieAfterMissingSeconds = 60,
+                ZombieMinConsecutiveMisses = 3,
+                ZombieCheckIntervalSeconds = 30,
+                ManagementStatusRefreshSeconds = 30
+            }),
+            active,
+            lifetime,
+            cache,
+            new NoOpProxySessionAuditService(),
+            Mock.Of<ILogger<ProxyZombieConnectionMonitorService>>());
+
+        var refreshTask = cache.RefreshAsync(CancellationToken.None);
+        telnet.SimulateIncomingData(
+            "CLIENT_LIST\tother\t127.0.0.1:59999\t10.51.16.2\t\t10\t20\t1\tUNDEF\nEND");
+        await refreshTask;
+
+        var missingField = typeof(ProxyZombieConnectionMonitorService)
+            .GetField("_missingSinceUtc", System.Reflection.BindingFlags.NonPublic | System.Reflection.BindingFlags.Instance)!;
+        var missingDict = (System.Collections.Concurrent.ConcurrentDictionary<string, DateTime>)missingField.GetValue(monitor)!;
+        missingDict["conn-zombie"] = DateTime.UtcNow.AddSeconds(-120);
+
+        monitor.CheckActiveConnections();
+        monitor.CheckActiveConnections();
+        monitor.CheckActiveConnections();
+
+        Assert.True(cts.IsCancellationRequested);
+    }
+
+    [Fact]
+    public async Task CheckActiveConnections_DoesNotTerminate_WhenClientListEmptyButProxyActive()
+    {
+        var active = new ActiveProxyConnectionService();
+        active.Add(new ActiveProxyConnection
+        {
+            ConnectionId = "conn-live",
+            Protocol = ProxyConnectionProtocol.Udp,
+            RealClientIp = "203.0.113.1",
+            RealClientPort = 50000,
+            LocalProxyIp = "127.0.0.1",
+            LocalProxyPort = 60123,
+            TargetIp = "127.0.0.1",
+            TargetPort = 1194,
+            ConnectedAtUtc = DateTime.UtcNow.AddMinutes(-1)
+        });
+
+        using var cts = new CancellationTokenSource();
+        var lifetime = new ProxyConnectionLifetimeService(new NoOpProxySessionAuditService(), Mock.Of<ILogger<ProxyConnectionLifetimeService>>());
+        lifetime.Register("conn-live", cts);
+
+        var telnet = new FakeTelnetClient();
+        var management = new OpenVpnManagementSignalService(telnet, Mock.Of<ILogger<CommandQueue>>());
+        var cache = new OpenVpnManagementStatusCache(management, new NoOpProxySessionAuditService(), Mock.Of<ILogger<OpenVpnManagementStatusCache>>());
+
+        var monitor = new ProxyZombieConnectionMonitorService(
+            Options.Create(new OpenVpnProxyOptions
+            {
+                CloseZombieAfterMissingSeconds = 30,
+                ZombieMinConsecutiveMisses = 1,
+                ManagementStatusRefreshSeconds = 30
+            }),
+            active,
+            lifetime,
+            cache,
+            new NoOpProxySessionAuditService(),
+            Mock.Of<ILogger<ProxyZombieConnectionMonitorService>>());
+
+        var refreshTask = cache.RefreshAsync(CancellationToken.None);
+        telnet.SimulateIncomingData("END");
+        await refreshTask;
+
+        monitor.CheckActiveConnections();
+
+        Assert.False(cts.IsCancellationRequested);
+    }
+
+    [Fact]
+    public void TryTerminate_CancelsRegisteredConnection()
+    {
+        using var cts = new CancellationTokenSource();
+        var lifetime = new ProxyConnectionLifetimeService(new NoOpProxySessionAuditService(), Mock.Of<ILogger<ProxyConnectionLifetimeService>>());
+        lifetime.Register("conn-1", cts);
+
+        Assert.True(lifetime.TryTerminate("conn-1", "test"));
+        Assert.True(cts.IsCancellationRequested);
+        Assert.False(lifetime.TryTerminate("conn-1", "test"));
+    }
+}

--- a/DataGateOpenVpnManager/Configurations/ProxyConfiguration.cs
+++ b/DataGateOpenVpnManager/Configurations/ProxyConfiguration.cs
@@ -1,3 +1,4 @@
+using DataGateOpenVpnManager.Models;
 using DataGateOpenVpnManager.Services.Proxy;
 
 namespace DataGateOpenVpnManager.Configurations;
@@ -6,10 +7,39 @@ public static class ProxyConfiguration
 {
     public static void ConfigureProxy(this IServiceCollection services, IConfiguration config)
     {
+        services.Configure<OpenVpnProxyOptions>(config.GetSection("OpenVpnProxy"));
+        services.PostConfigure<OpenVpnProxyOptions>(options => ApplyLegacyByteDebugEnv(config, options));
+
         services.AddSingleton<IProxyConnectionHistoryService, ProxyConnectionHistoryService>();
         services.AddSingleton<IActiveProxyConnectionService, ActiveProxyConnectionService>();
         services.AddSingleton<IProxyConnectionIdentityResolver, ProxyConnectionIdentityResolver>();
         services.AddSingleton<IProxyTrafficFlowService, ProxyTrafficFlowService>();
+        services.AddSingleton<IProxyConnectionLifetimeService, ProxyConnectionLifetimeService>();
+        services.AddSingleton<IProxySessionAuditService, ProxySessionAuditService>();
+        services.AddSingleton<IOpenVpnManagementStatusCache, OpenVpnManagementStatusCache>();
+        services.AddHostedService<OpenVpnManagementStatusRefreshService>();
+        services.AddSingleton<ProxyByteDebugService>();
+        services.AddSingleton<IProxyByteDebugService>(sp => sp.GetRequiredService<ProxyByteDebugService>());
         services.AddHostedService<ProxyTrafficFlowBroadcastService>();
+        services.AddHostedService<ProxyByteDebugMonitorService>();
+        services.AddHostedService<ProxyZombieConnectionMonitorService>();
+    }
+
+    private static void ApplyLegacyByteDebugEnv(IConfiguration config, OpenVpnProxyOptions options)
+    {
+        if (options.ByteDebug)
+            return;
+
+        var legacy = config["PROXY_BYTE_DEBUG"];
+        if (string.IsNullOrWhiteSpace(legacy))
+            return;
+
+        if (bool.TryParse(legacy, out var enabled))
+        {
+            options.ByteDebug = enabled;
+            return;
+        }
+
+        options.ByteDebug = legacy is "1" or "yes" or "on";
     }
 }

--- a/DataGateOpenVpnManager/Controllers/DiagnosticsController.cs
+++ b/DataGateOpenVpnManager/Controllers/DiagnosticsController.cs
@@ -1,0 +1,221 @@
+using System.Net;
+using System.Net.Sockets;
+using DataGateOpenVpnManager.Services.Proxy;
+using DataGateMonitor.SharedModels.Responses;
+using Microsoft.AspNetCore.Mvc;
+
+namespace DataGateOpenVpnManager.Controllers;
+
+[ApiController]
+[Route("api/diagnostics")]
+public class DiagnosticsController(
+    IConfiguration config,
+    IActiveProxyConnectionService activeProxyConnections,
+    IProxyTrafficFlowService trafficFlow,
+    IOpenVpnManagementStatusCache statusCache,
+    IProxySessionAuditService sessionAudit,
+    ILogger<DiagnosticsController> logger) : ControllerBase
+{
+    [HttpGet("proxy-audit")]
+    public ActionResult<ApiResponse<ProxyAuditDiagnosticsResponse>> GetProxyAudit([FromQuery] int limit = 100)
+    {
+        var entries = sessionAudit.GetRecent(limit);
+        return Ok(ApiResponse<ProxyAuditDiagnosticsResponse>.SuccessResponse(new ProxyAuditDiagnosticsResponse
+        {
+            CheckedAtUtc = DateTime.UtcNow,
+            Count = entries.Count,
+            Entries = entries
+        }));
+    }
+
+    [HttpGet("proxy-sessions")]
+    public async Task<ActionResult<ApiResponse<ProxySessionDiagnosticsResponse>>> GetProxySessions(
+        CancellationToken cancellationToken)
+    {
+        try
+        {
+            var dnsTarget = config["DNS1"] ?? "10.51.15.1";
+            var snapshot = statusCache.GetSnapshot();
+            if (snapshot is null || !snapshot.IsValid)
+            {
+                await statusCache.RefreshAsync(cancellationToken);
+                snapshot = statusCache.GetSnapshot();
+            }
+
+            var mgmtClients = snapshot?.Clients.ToList() ?? [];
+            var dns = await ProbeDnsAsync(dnsTarget, cancellationToken);
+
+            var sessions = activeProxyConnections.GetAll()
+                .Select(conn =>
+                {
+                    trafficFlow.TryGetTotals(conn.ConnectionId, out var c2s, out var s2c);
+                    var mgmt = OpenVpnManagementStatusParser.FindByLocalProxyPort(
+                        mgmtClients,
+                        conn.LocalProxyIp,
+                        conn.LocalProxyPort);
+
+                    return new ProxySessionDiagnosticItem
+                    {
+                        ConnectionId = conn.ConnectionId,
+                        Protocol = conn.Protocol.ToString(),
+                        RealClient = $"{conn.RealClientIp}:{conn.RealClientPort}",
+                        LocalProxy = $"{conn.LocalProxyIp}:{conn.LocalProxyPort}",
+                        ConnectedAtUtc = conn.ConnectedAtUtc,
+                        ProxyClientToServerBytes = c2s,
+                        ProxyServerToClientBytes = s2c,
+                        InOpenVpnManagement = mgmt is not null,
+                        IsZombie = mgmt is null,
+                        OpenVpnCommonName = mgmt?.CommonName,
+                        OpenVpnVirtualAddress = mgmt?.VirtualAddress,
+                        ManagementBytesReceived = mgmt?.BytesReceived,
+                        ManagementBytesSent = mgmt?.BytesSent
+                    };
+                })
+                .OrderBy(s => s.ConnectedAtUtc)
+                .ToList();
+
+            var response = new ProxySessionDiagnosticsResponse
+            {
+                CheckedAtUtc = DateTime.UtcNow,
+                ManagementStatusAvailable = snapshot?.IsValid == true,
+                ManagementStatusAgeSeconds = snapshot is null
+                    ? null
+                    : (DateTime.UtcNow - snapshot.FetchedAtUtc).TotalSeconds,
+                ManagementClientCount = mgmtClients.Count,
+                ActiveProxySessionCount = sessions.Count,
+                ZombieSessionCount = sessions.Count(s => s.IsZombie),
+                DnsProbeTarget = dnsTarget,
+                DnsProbe = dns,
+                Sessions = sessions
+            };
+
+            return Ok(ApiResponse<ProxySessionDiagnosticsResponse>.SuccessResponse(response));
+        }
+        catch (Exception ex)
+        {
+            logger.LogError(ex, "Proxy session diagnostics failed");
+            return BadRequest(ApiResponse<ProxySessionDiagnosticsResponse>.ErrorResponse(ex.Message));
+        }
+    }
+
+    private static async Task<DnsProbeResult> ProbeDnsAsync(string dnsHost, CancellationToken cancellationToken)
+    {
+        if (!IPAddress.TryParse(dnsHost, out var ip))
+        {
+            return new DnsProbeResult
+            {
+                Host = dnsHost,
+                Port = 53,
+                Error = "DNS host is not an IPv4 address"
+            };
+        }
+
+        try
+        {
+            using var udp = new UdpClient();
+            udp.Client.ReceiveTimeout = 2000;
+            udp.Client.SendTimeout = 2000;
+            var query = BuildDnsQuery("youtube.com");
+            await udp.SendAsync(query, query.Length, new IPEndPoint(ip, 53));
+            using var timeoutCts = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
+            timeoutCts.CancelAfter(TimeSpan.FromSeconds(2));
+            var reply = await udp.ReceiveAsync(timeoutCts.Token);
+            return new DnsProbeResult
+            {
+                Host = dnsHost,
+                Port = 53,
+                Responded = reply.Buffer.Length > 0,
+                ResponseBytes = reply.Buffer.Length
+            };
+        }
+        catch (OperationCanceledException) when (!cancellationToken.IsCancellationRequested)
+        {
+            return new DnsProbeResult
+            {
+                Host = dnsHost,
+                Port = 53,
+                Error = "UDP DNS query timed out after 2s"
+            };
+        }
+        catch (Exception ex)
+        {
+            return new DnsProbeResult
+            {
+                Host = dnsHost,
+                Port = 53,
+                Error = ex.Message
+            };
+        }
+    }
+
+    private static byte[] BuildDnsQuery(string hostName)
+    {
+        // Minimal standard query: ID=0xAA55, recursion desired, one A question.
+        var hostLabels = hostName.Split('.', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries);
+        using var ms = new MemoryStream();
+        ms.WriteByte(0xAA);
+        ms.WriteByte(0x55);
+        ms.WriteByte(0x01); // flags hi
+        ms.WriteByte(0x00); // flags lo
+        ms.WriteByte(0x00); ms.WriteByte(0x01); // QDCOUNT
+        ms.WriteByte(0x00); ms.WriteByte(0x00); // ANCOUNT
+        ms.WriteByte(0x00); ms.WriteByte(0x00); // NSCOUNT
+        ms.WriteByte(0x00); ms.WriteByte(0x00); // ARCOUNT
+        foreach (var label in hostLabels)
+        {
+            var bytes = System.Text.Encoding.ASCII.GetBytes(label);
+            ms.WriteByte((byte)bytes.Length);
+            ms.Write(bytes);
+        }
+        ms.WriteByte(0x00);
+        ms.WriteByte(0x00); ms.WriteByte(0x01); // TYPE A
+        ms.WriteByte(0x00); ms.WriteByte(0x01); // CLASS IN
+        return ms.ToArray();
+    }
+}
+
+public sealed class ProxySessionDiagnosticsResponse
+{
+    public required DateTime CheckedAtUtc { get; init; }
+    public required bool ManagementStatusAvailable { get; init; }
+    public double? ManagementStatusAgeSeconds { get; init; }
+    public required int ManagementClientCount { get; init; }
+    public required int ActiveProxySessionCount { get; init; }
+    public required int ZombieSessionCount { get; init; }
+    public required string DnsProbeTarget { get; init; }
+    public required DnsProbeResult DnsProbe { get; init; }
+    public required IReadOnlyList<ProxySessionDiagnosticItem> Sessions { get; init; }
+}
+
+public sealed class ProxySessionDiagnosticItem
+{
+    public required string ConnectionId { get; init; }
+    public required string Protocol { get; init; }
+    public required string RealClient { get; init; }
+    public required string LocalProxy { get; init; }
+    public required DateTime ConnectedAtUtc { get; init; }
+    public required long ProxyClientToServerBytes { get; init; }
+    public required long ProxyServerToClientBytes { get; init; }
+    public required bool InOpenVpnManagement { get; init; }
+    public required bool IsZombie { get; init; }
+    public string? OpenVpnCommonName { get; init; }
+    public string? OpenVpnVirtualAddress { get; init; }
+    public long? ManagementBytesReceived { get; init; }
+    public long? ManagementBytesSent { get; init; }
+}
+
+public sealed class DnsProbeResult
+{
+    public required string Host { get; init; }
+    public required int Port { get; init; }
+    public bool Responded { get; init; }
+    public int ResponseBytes { get; init; }
+    public string? Error { get; init; }
+}
+
+public sealed class ProxyAuditDiagnosticsResponse
+{
+    public required DateTime CheckedAtUtc { get; init; }
+    public required int Count { get; init; }
+    public required IReadOnlyList<ProxySessionAuditEntry> Entries { get; init; }
+}

--- a/DataGateOpenVpnManager/Controllers/DiagnosticsController.cs
+++ b/DataGateOpenVpnManager/Controllers/DiagnosticsController.cs
@@ -1,8 +1,10 @@
 using System.Net;
 using System.Net.Sockets;
+using DataGateOpenVpnManager.Models;
 using DataGateOpenVpnManager.Services.Proxy;
 using DataGateMonitor.SharedModels.Responses;
 using Microsoft.AspNetCore.Mvc;
+using Microsoft.Extensions.Options;
 
 namespace DataGateOpenVpnManager.Controllers;
 
@@ -10,6 +12,7 @@ namespace DataGateOpenVpnManager.Controllers;
 [Route("api/diagnostics")]
 public class DiagnosticsController(
     IConfiguration config,
+    IOptions<OpenVpnProxyOptions> proxyOptions,
     IActiveProxyConnectionService activeProxyConnections,
     IProxyTrafficFlowService trafficFlow,
     IOpenVpnManagementStatusCache statusCache,
@@ -44,6 +47,10 @@ public class DiagnosticsController(
 
             var mgmtClients = snapshot?.Clients.ToList() ?? [];
             var dns = await ProbeDnsAsync(dnsTarget, cancellationToken);
+            var canEvaluatePeers = ProxyManagementPeerDiagnostics.CanEvaluatePeerPresence(
+                snapshot,
+                proxyOptions.Value,
+                out var peerEvaluationSkipReason);
 
             var sessions = activeProxyConnections.GetAll()
                 .Select(conn =>
@@ -53,6 +60,10 @@ public class DiagnosticsController(
                         mgmtClients,
                         conn.LocalProxyIp,
                         conn.LocalProxyPort);
+                    var missingFromManagement = mgmt is null;
+                    var isZombie = canEvaluatePeers
+                                   && snapshot is not null
+                                   && ProxyManagementPeerDiagnostics.IsLikelyZombie(conn, mgmt, snapshot);
 
                     return new ProxySessionDiagnosticItem
                     {
@@ -64,7 +75,8 @@ public class DiagnosticsController(
                         ProxyClientToServerBytes = c2s,
                         ProxyServerToClientBytes = s2c,
                         InOpenVpnManagement = mgmt is not null,
-                        IsZombie = mgmt is null,
+                        MissingFromManagement = missingFromManagement,
+                        IsZombie = isZombie,
                         OpenVpnCommonName = mgmt?.CommonName,
                         OpenVpnVirtualAddress = mgmt?.VirtualAddress,
                         ManagementBytesReceived = mgmt?.BytesReceived,
@@ -82,9 +94,14 @@ public class DiagnosticsController(
                     ? null
                     : (DateTime.UtcNow - snapshot.FetchedAtUtc).TotalSeconds,
                 ManagementClientCount = mgmtClients.Count,
+                PeerEvaluationAvailable = canEvaluatePeers,
+                PeerEvaluationSkipReason = peerEvaluationSkipReason,
                 ActiveProxySessionCount = sessions.Count,
                 ZombieSessionCount = sessions.Count(s => s.IsZombie),
                 DnsProbeTarget = dnsTarget,
+                DnsProbeScope = "host-default-route",
+                DnsProbeNote =
+                    "UDP probe uses the host default route, not the VPN client path (e.g. tun1/UFW may differ).",
                 DnsProbe = dns,
                 Sessions = sessions
             };
@@ -180,9 +197,13 @@ public sealed class ProxySessionDiagnosticsResponse
     public required bool ManagementStatusAvailable { get; init; }
     public double? ManagementStatusAgeSeconds { get; init; }
     public required int ManagementClientCount { get; init; }
+    public required bool PeerEvaluationAvailable { get; init; }
+    public string? PeerEvaluationSkipReason { get; init; }
     public required int ActiveProxySessionCount { get; init; }
     public required int ZombieSessionCount { get; init; }
     public required string DnsProbeTarget { get; init; }
+    public required string DnsProbeScope { get; init; }
+    public required string DnsProbeNote { get; init; }
     public required DnsProbeResult DnsProbe { get; init; }
     public required IReadOnlyList<ProxySessionDiagnosticItem> Sessions { get; init; }
 }
@@ -197,6 +218,7 @@ public sealed class ProxySessionDiagnosticItem
     public required long ProxyClientToServerBytes { get; init; }
     public required long ProxyServerToClientBytes { get; init; }
     public required bool InOpenVpnManagement { get; init; }
+    public required bool MissingFromManagement { get; init; }
     public required bool IsZombie { get; init; }
     public string? OpenVpnCommonName { get; init; }
     public string? OpenVpnVirtualAddress { get; init; }

--- a/DataGateOpenVpnManager/Controllers/DiagnosticsController.cs
+++ b/DataGateOpenVpnManager/Controllers/DiagnosticsController.cs
@@ -2,6 +2,7 @@ using System.Net;
 using System.Net.Sockets;
 using DataGateOpenVpnManager.Models;
 using DataGateOpenVpnManager.Services.Proxy;
+using DataGateMonitor.SharedModels.DataGateOpenVpnManager.Diagnostics.Responses;
 using DataGateMonitor.SharedModels.Responses;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.Extensions.Options;
@@ -22,7 +23,9 @@ public class DiagnosticsController(
     [HttpGet("proxy-audit")]
     public ActionResult<ApiResponse<ProxyAuditDiagnosticsResponse>> GetProxyAudit([FromQuery] int limit = 100)
     {
-        var entries = sessionAudit.GetRecent(limit);
+        var entries = sessionAudit.GetRecent(limit)
+            .Select(MapAuditEntry)
+            .ToList();
         return Ok(ApiResponse<ProxyAuditDiagnosticsResponse>.SuccessResponse(new ProxyAuditDiagnosticsResponse
         {
             CheckedAtUtc = DateTime.UtcNow,
@@ -115,6 +118,16 @@ public class DiagnosticsController(
         }
     }
 
+    private static ProxySessionAuditEntryDto MapAuditEntry(ProxySessionAuditEntry entry) => new()
+    {
+        AtUtc = entry.AtUtc,
+        Event = entry.Event,
+        ConnectionId = entry.ConnectionId,
+        Decision = entry.Decision,
+        Reason = entry.Reason,
+        Details = entry.Details
+    };
+
     private static async Task<DnsProbeResult> ProbeDnsAsync(string dnsHost, CancellationToken cancellationToken)
     {
         if (!IPAddress.TryParse(dnsHost, out var ip))
@@ -189,55 +202,4 @@ public class DiagnosticsController(
         ms.WriteByte(0x00); ms.WriteByte(0x01); // CLASS IN
         return ms.ToArray();
     }
-}
-
-public sealed class ProxySessionDiagnosticsResponse
-{
-    public required DateTime CheckedAtUtc { get; init; }
-    public required bool ManagementStatusAvailable { get; init; }
-    public double? ManagementStatusAgeSeconds { get; init; }
-    public required int ManagementClientCount { get; init; }
-    public required bool PeerEvaluationAvailable { get; init; }
-    public string? PeerEvaluationSkipReason { get; init; }
-    public required int ActiveProxySessionCount { get; init; }
-    public required int ZombieSessionCount { get; init; }
-    public required string DnsProbeTarget { get; init; }
-    public required string DnsProbeScope { get; init; }
-    public required string DnsProbeNote { get; init; }
-    public required DnsProbeResult DnsProbe { get; init; }
-    public required IReadOnlyList<ProxySessionDiagnosticItem> Sessions { get; init; }
-}
-
-public sealed class ProxySessionDiagnosticItem
-{
-    public required string ConnectionId { get; init; }
-    public required string Protocol { get; init; }
-    public required string RealClient { get; init; }
-    public required string LocalProxy { get; init; }
-    public required DateTime ConnectedAtUtc { get; init; }
-    public required long ProxyClientToServerBytes { get; init; }
-    public required long ProxyServerToClientBytes { get; init; }
-    public required bool InOpenVpnManagement { get; init; }
-    public required bool MissingFromManagement { get; init; }
-    public required bool IsZombie { get; init; }
-    public string? OpenVpnCommonName { get; init; }
-    public string? OpenVpnVirtualAddress { get; init; }
-    public long? ManagementBytesReceived { get; init; }
-    public long? ManagementBytesSent { get; init; }
-}
-
-public sealed class DnsProbeResult
-{
-    public required string Host { get; init; }
-    public required int Port { get; init; }
-    public bool Responded { get; init; }
-    public int ResponseBytes { get; init; }
-    public string? Error { get; init; }
-}
-
-public sealed class ProxyAuditDiagnosticsResponse
-{
-    public required DateTime CheckedAtUtc { get; init; }
-    public required int Count { get; init; }
-    public required IReadOnlyList<ProxySessionAuditEntry> Entries { get; init; }
 }

--- a/DataGateOpenVpnManager/Controllers/OpenVpnProxyController.cs
+++ b/DataGateOpenVpnManager/Controllers/OpenVpnProxyController.cs
@@ -19,7 +19,10 @@ public class OpenVpnProxyController(
     IActiveProxyConnectionService activeProxyConnections,
     IProxyConnectionHistoryService proxyConnectionHistory,
     IProxyTrafficFlowService proxyTrafficFlow,
-    IProxyConnectionIdentityResolver identityResolver) : ControllerBase
+    IProxyConnectionIdentityResolver identityResolver,
+    IProxyByteDebugService proxyByteDebug,
+    IProxyConnectionLifetimeService connectionLifetime,
+    IProxySessionAuditService sessionAudit) : ControllerBase
 {
     private const int MaxUdpDatagramSize = 64 * 1024;
     private const int WsSegmentSize = 16 * 1024;
@@ -90,6 +93,7 @@ public class OpenVpnProxyController(
         var modeNorm = (mode ?? "tcp").Trim().ToLowerInvariant();
         var identity = identityResolver.Resolve(HttpContext, clientRef);
         var connectionId = Guid.NewGuid().ToString("N");
+        connectionLifetime.Register(connectionId, linkedCts);
 
         try
         {
@@ -105,6 +109,10 @@ public class OpenVpnProxyController(
         catch (Exception e)
         {
             logger.LogDebug(e, "Proxy failed. mode={Mode} {Message}", modeNorm, e.Message);
+        }
+        finally
+        {
+            connectionLifetime.Unregister(connectionId);
         }
 
         try
@@ -322,6 +330,19 @@ public class OpenVpnProxyController(
         activeProxyConnections.Add(connection);
         proxyTrafficFlow.RegisterConnection(connection, identity);
 
+        var connectDetails = ProxyAuditDetails.ForConnection(connection);
+        if (identity?.ClientRef is not null)
+            connectDetails["clientRef"] = identity.ClientRef;
+        sessionAudit.Record(new ProxySessionAuditEntry
+        {
+            AtUtc = DateTime.UtcNow,
+            Event = "proxy.connected",
+            ConnectionId = connectionId,
+            Decision = "ok",
+            Reason = protocol.ToString(),
+            Details = connectDetails
+        });
+
         proxyConnectionHistory.Add(new ProxyConnectionHistoryItem
         {
             ConnectionId = connectionId,
@@ -339,15 +360,34 @@ public class OpenVpnProxyController(
 
     private void UnregisterConnection(string connectionId)
     {
-        if (!activeProxyConnections.TryGet(connectionId, out var conn) || conn is null)
-        {
-            activeProxyConnections.Remove(connectionId);
-            proxyTrafficFlow.UnregisterConnection(connectionId);
-            return;
-        }
+        ActiveProxyConnection? conn = null;
+        if (activeProxyConnections.TryGet(connectionId, out var existing))
+            conn = existing;
 
         activeProxyConnections.Remove(connectionId);
-        proxyTrafficFlow.UnregisterConnection(connectionId);
+        var terminal = proxyTrafficFlow.UnregisterConnection(connectionId);
+        if (terminal is not null)
+        {
+            proxyByteDebug.ReportDisconnect(terminal);
+            var disconnectDetails = new Dictionary<string, string>
+            {
+                ["proxyC2S"] = terminal.ClientToServerBytesTotal.ToString(System.Globalization.CultureInfo.InvariantCulture),
+                ["proxyS2C"] = terminal.ServerToClientBytesTotal.ToString(System.Globalization.CultureInfo.InvariantCulture),
+                ["local"] = $"{terminal.LocalProxyIp}:{terminal.LocalProxyPort}"
+            };
+            sessionAudit.Record(new ProxySessionAuditEntry
+            {
+                AtUtc = DateTime.UtcNow,
+                Event = "proxy.disconnected",
+                ConnectionId = connectionId,
+                Decision = "closed",
+                Reason = "pump finished",
+                Details = disconnectDetails
+            });
+        }
+
+        if (conn is null)
+            return;
 
         proxyConnectionHistory.Add(new ProxyConnectionHistoryItem
         {

--- a/DataGateOpenVpnManager/DataGateOpenVpnManager.csproj
+++ b/DataGateOpenVpnManager/DataGateOpenVpnManager.csproj
@@ -5,8 +5,8 @@
         <Nullable>enable</Nullable>
         <ImplicitUsings>enable</ImplicitUsings>
         <ApplicationIcon>wwwroot\favicon.ico</ApplicationIcon>
-        <AssemblyVersion>1.2.5.58</AssemblyVersion>
-        <FileVersion>1.2.5.58</FileVersion>
+        <AssemblyVersion>1.2.5.65</AssemblyVersion>
+        <FileVersion>1.2.5.65</FileVersion>
         <RootNamespace>DataGateOpenVpnManager</RootNamespace>
     </PropertyGroup>
 

--- a/DataGateOpenVpnManager/DataGateOpenVpnManager.csproj
+++ b/DataGateOpenVpnManager/DataGateOpenVpnManager.csproj
@@ -17,7 +17,7 @@
         <PackageReference Include="Microsoft.AspNetCore.SignalR.Protocols.NewtonsoftJson" Version="10.0.8" />
         <PackageReference Include="Newtonsoft.Json" Version="13.0.4" />
         <!-- DataGateMonitor.SharedModels: NuGet package only; do not use ProjectReference to the SharedModels .csproj. -->
-        <PackageReference Include="DataGateMonitor.SharedModels" Version="1.0.20" />
+        <PackageReference Include="DataGateMonitor.SharedModels" Version="1.0.25" />
         <PackageReference Include="Serilog" Version="4.3.1" />
         <PackageReference Include="Serilog.Extensions.Hosting" Version="10.0.0" />
         <PackageReference Include="Serilog.Extensions.Logging" Version="10.0.0" />

--- a/DataGateOpenVpnManager/Middlewares/JwtValidationMiddleware.cs
+++ b/DataGateOpenVpnManager/Middlewares/JwtValidationMiddleware.cs
@@ -12,6 +12,8 @@ public class JwtValidationMiddleware(RequestDelegate next)
 
     private static readonly string[] LocalOnlyPaths =
     {
+        "/api/info",
+        "/api/diagnostics",
         "/api/vpn-events/connect",
         "/api/vpn-events/disconnect",
         "/api/vpn-events/tlsverify",

--- a/DataGateOpenVpnManager/Models/OpenVpnProxyOptions.cs
+++ b/DataGateOpenVpnManager/Models/OpenVpnProxyOptions.cs
@@ -55,4 +55,8 @@ public sealed class OpenVpnProxyOptions
     public int ManagementStatusRefreshSeconds { get; set; } = 30;
 
     internal bool IsSessionAuditEnabled => SessionAudit || ByteDebug;
+
+    internal bool NeedsBackgroundManagementRefresh =>
+        CloseZombieAfterMissingSeconds > 0
+        || ByteDebug && ByteDebugIntervalSeconds > 0;
 }

--- a/DataGateOpenVpnManager/Models/OpenVpnProxyOptions.cs
+++ b/DataGateOpenVpnManager/Models/OpenVpnProxyOptions.cs
@@ -1,0 +1,58 @@
+namespace DataGateOpenVpnManager.Models;
+
+public sealed class OpenVpnProxyOptions
+{
+    /// <summary>
+    /// When enabled, logs per-connection proxy byte totals and compares them with OpenVPN management (status 3).
+    /// Env: <c>OpenVpnProxy__ByteDebug=true</c> or <c>PROXY_BYTE_DEBUG=1</c>.
+    /// </summary>
+    public bool ByteDebug { get; set; }
+
+    /// <summary>
+    /// Structured investigation log: every proxy/management/zombie decision with context.
+    /// Enabled automatically when <see cref="ByteDebug"/> is true.
+    /// Env: <c>OpenVpnProxy__SessionAudit=true</c>.
+    /// </summary>
+    public bool SessionAudit { get; set; }
+
+    /// <summary>
+    /// In-memory audit ring buffer size exposed via /api/diagnostics/proxy-audit.
+    /// </summary>
+    public int SessionAuditBufferSize { get; set; } = 500;
+
+    /// <summary>
+    /// Optional periodic comparison interval in seconds for active connections. 0 = disconnect-only.
+    /// Env: <c>OpenVpnProxy__ByteDebugIntervalSeconds</c>.
+    /// </summary>
+    public int ByteDebugIntervalSeconds { get; set; }
+
+    /// <summary>
+    /// Log a warning when proxy vs management delta exceeds this many bytes (per direction).
+    /// </summary>
+    public long ByteDebugWarnDeltaBytes { get; set; } = 4096;
+
+    /// <summary>
+    /// Close WSS proxy when the OpenVPN peer disappears from management for this long (seconds). 0 = disabled.
+    /// Env: <c>OpenVpnProxy__CloseZombieAfterMissingSeconds</c>.
+    /// </summary>
+    public int CloseZombieAfterMissingSeconds { get; set; }
+
+    /// <summary>
+    /// Require this many consecutive cache misses before terminating a proxy session.
+    /// </summary>
+    public int ZombieMinConsecutiveMisses { get; set; } = 3;
+
+    /// <summary>
+    /// How often to check active proxy sessions against OpenVPN management.
+    /// Env: <c>OpenVpnProxy__ZombieCheckIntervalSeconds</c>.
+    /// </summary>
+    public int ZombieCheckIntervalSeconds { get; set; } = 30;
+
+    /// <summary>
+    /// Single shared OpenVPN management status poll interval (seconds).
+    /// Env: <c>OpenVpnProxy__ManagementStatusRefreshSeconds</c>.
+    /// </summary>
+    public int ManagementStatusRefreshSeconds { get; set; } = 30;
+
+    internal bool IsSessionAuditEnabled => SessionAudit || ByteDebug;
+}

--- a/DataGateOpenVpnManager/Services/OpenVpnTelnet/CommandQueue.cs
+++ b/DataGateOpenVpnManager/Services/OpenVpnTelnet/CommandQueue.cs
@@ -5,16 +5,19 @@ namespace DataGateOpenVpnManager.Services.OpenVpnTelnet;
 public class CommandQueue : ICommandQueue, IAsyncDisposable
 {
     private readonly ConcurrentQueue<string> _messageQueue = new();
-    private readonly ConcurrentQueue<PendingCommand> _pendingCommands = new();
     private readonly TelnetClient _telnetClient;
     private readonly List<IMessageSubscriber> _subscribers = new();
     private readonly Lock _subscriberLock = new();
+    private readonly Lock _pendingLock = new();
 
     private readonly CancellationTokenSource _cts = new();
     private readonly ILogger<CommandQueue> _logger;
     private readonly SemaphoreSlim _commandLock = new(1, 1);
 
-    private record PendingCommand(string CommandText, TaskCompletionSource<string> TaskSource);
+    private PendingCommand? _activePending;
+    private long _nextCommandSequence;
+
+    private sealed record PendingCommand(long Sequence, string CommandText, TaskCompletionSource<string> TaskSource);
 
     public bool HasSubscribers
     {
@@ -60,14 +63,22 @@ public class CommandQueue : ICommandQueue, IAsyncDisposable
 
         if (OpenVpnManagementMessageCompletion.IsComplete(trimmed))
         {
-            if (_pendingCommands.TryDequeue(out var pending))
+            PendingCommand? pending;
+            lock (_pendingLock)
+                pending = _activePending;
+
+            if (pending is not null && !pending.TaskSource.Task.IsCompleted)
             {
-                if (!pending.TaskSource.Task.IsCompleted)
-                    pending.TaskSource.TrySetResult(trimmed);
+                pending.TaskSource.TrySetResult(trimmed);
+                lock (_pendingLock)
+                {
+                    if (ReferenceEquals(_activePending, pending))
+                        _activePending = null;
+                }
             }
             else
             {
-                _logger.LogDebug("[CommandQueue] No pending command found, adding to queue.");
+                _logger.LogDebug("[CommandQueue] Orphan management response, adding to queue.");
                 _messageQueue.Enqueue(trimmed);
                 NotifySubscribers(trimmed, cancellationToken);
             }
@@ -112,9 +123,10 @@ public class CommandQueue : ICommandQueue, IAsyncDisposable
             await _telnetClient.EnsureConnectedAsync(cancellationToken);
 
             var tcs = new TaskCompletionSource<string>(TaskCreationOptions.RunContinuationsAsynchronously);
-            var pendingCommand = new PendingCommand(command, tcs);
+            var pendingCommand = new PendingCommand(Interlocked.Increment(ref _nextCommandSequence), command, tcs);
 
-            _pendingCommands.Enqueue(pendingCommand);
+            lock (_pendingLock)
+                _activePending = pendingCommand;
 
             try
             {
@@ -129,11 +141,9 @@ public class CommandQueue : ICommandQueue, IAsyncDisposable
                     _logger.LogInformation("[CommandQueue] ✅ Received response for command: {Command} → {Result}", command, result);
                     return result;
                 }
-            
-                if (_pendingCommands.TryDequeue(out var timedOutCommand) && timedOutCommand == pendingCommand)
-                {
-                    tcs.TrySetCanceled();
-                }
+
+                ClearActivePending(pendingCommand);
+                tcs.TrySetCanceled();
 
                 throw new TimeoutException($"[CommandQueue] Command \"{command}\" timed out after {timeoutMs}ms.");
             }
@@ -141,10 +151,8 @@ public class CommandQueue : ICommandQueue, IAsyncDisposable
             {
                 _logger.LogError(ex, "[CommandQueue] Exception in SendCommandAsync");
 
-                if (_pendingCommands.TryDequeue(out var erroredCommand) && erroredCommand == pendingCommand)
-                {
-                    tcs.TrySetException(ex);
-                }
+                ClearActivePending(pendingCommand);
+                tcs.TrySetException(ex);
 
                 throw;
             }
@@ -155,6 +163,15 @@ public class CommandQueue : ICommandQueue, IAsyncDisposable
         }
     }
 
+
+    private void ClearActivePending(PendingCommand pendingCommand)
+    {
+        lock (_pendingLock)
+        {
+            if (ReferenceEquals(_activePending, pendingCommand))
+                _activePending = null;
+        }
+    }
 
     public (bool result, string? message) TryGetMessage()
     {

--- a/DataGateOpenVpnManager/Services/OpenVpnTelnet/CommandQueue.cs
+++ b/DataGateOpenVpnManager/Services/OpenVpnTelnet/CommandQueue.cs
@@ -12,6 +12,7 @@ public class CommandQueue : ICommandQueue, IAsyncDisposable
 
     private readonly CancellationTokenSource _cts = new();
     private readonly ILogger<CommandQueue> _logger;
+    private readonly SemaphoreSlim _commandLock = new(1, 1);
 
     private record PendingCommand(string CommandText, TaskCompletionSource<string> TaskSource);
 
@@ -105,44 +106,52 @@ public class CommandQueue : ICommandQueue, IAsyncDisposable
         
         cancellationToken.ThrowIfCancellationRequested();
 
-        await _telnetClient.EnsureConnectedAsync(cancellationToken);
-
-        var tcs = new TaskCompletionSource<string>(TaskCreationOptions.RunContinuationsAsynchronously);
-        var pendingCommand = new PendingCommand(command, tcs);
-
-        _pendingCommands.Enqueue(pendingCommand);
-
+        await _commandLock.WaitAsync(cancellationToken);
         try
         {
-            await _telnetClient.SendAsync(command, cancellationToken);
+            await _telnetClient.EnsureConnectedAsync(cancellationToken);
 
-            var timeoutTask = Task.Delay(timeoutMs, cancellationToken);
-            var completedTask = await Task.WhenAny(tcs.Task, timeoutTask);
+            var tcs = new TaskCompletionSource<string>(TaskCreationOptions.RunContinuationsAsynchronously);
+            var pendingCommand = new PendingCommand(command, tcs);
 
-            if (completedTask == tcs.Task)
+            _pendingCommands.Enqueue(pendingCommand);
+
+            try
             {
-                var result = await tcs.Task; // can rethrow if tcs.Task faulted
-                _logger.LogInformation("[CommandQueue] ✅ Received response for command: {Command} → {Result}", command, result);
-                return result;
-            }
+                await _telnetClient.SendAsync(command, cancellationToken);
+
+                var timeoutTask = Task.Delay(timeoutMs, cancellationToken);
+                var completedTask = await Task.WhenAny(tcs.Task, timeoutTask);
+
+                if (completedTask == tcs.Task)
+                {
+                    var result = await tcs.Task;
+                    _logger.LogInformation("[CommandQueue] ✅ Received response for command: {Command} → {Result}", command, result);
+                    return result;
+                }
             
-            if (_pendingCommands.TryDequeue(out var timedOutCommand) && timedOutCommand == pendingCommand)
-            {
-                tcs.TrySetCanceled();
-            }
+                if (_pendingCommands.TryDequeue(out var timedOutCommand) && timedOutCommand == pendingCommand)
+                {
+                    tcs.TrySetCanceled();
+                }
 
-            throw new TimeoutException($"[CommandQueue] Command \"{command}\" timed out after {timeoutMs}ms.");
+                throw new TimeoutException($"[CommandQueue] Command \"{command}\" timed out after {timeoutMs}ms.");
+            }
+            catch (Exception ex)
+            {
+                _logger.LogError(ex, "[CommandQueue] Exception in SendCommandAsync");
+
+                if (_pendingCommands.TryDequeue(out var erroredCommand) && erroredCommand == pendingCommand)
+                {
+                    tcs.TrySetException(ex);
+                }
+
+                throw;
+            }
         }
-        catch (Exception ex)
+        finally
         {
-            _logger.LogError(ex, "[CommandQueue] Exception in SendCommandAsync");
-
-            if (_pendingCommands.TryDequeue(out var erroredCommand) && erroredCommand == pendingCommand)
-            {
-                tcs.TrySetException(ex);
-            }
-
-            throw;
+            _commandLock.Release();
         }
     }
 

--- a/DataGateOpenVpnManager/Services/Proxy/IProxyByteDebugService.cs
+++ b/DataGateOpenVpnManager/Services/Proxy/IProxyByteDebugService.cs
@@ -1,0 +1,6 @@
+namespace DataGateOpenVpnManager.Services.Proxy;
+
+public interface IProxyByteDebugService
+{
+    void ReportDisconnect(ProxyTrafficFlowUpdate update);
+}

--- a/DataGateOpenVpnManager/Services/Proxy/IProxyConnectionLifetimeService.cs
+++ b/DataGateOpenVpnManager/Services/Proxy/IProxyConnectionLifetimeService.cs
@@ -1,0 +1,8 @@
+namespace DataGateOpenVpnManager.Services.Proxy;
+
+public interface IProxyConnectionLifetimeService
+{
+    void Register(string connectionId, CancellationTokenSource cancellation);
+    void Unregister(string connectionId);
+    bool TryTerminate(string connectionId, string reason);
+}

--- a/DataGateOpenVpnManager/Services/Proxy/IProxyTrafficFlowService.cs
+++ b/DataGateOpenVpnManager/Services/Proxy/IProxyTrafficFlowService.cs
@@ -6,7 +6,8 @@ namespace DataGateOpenVpnManager.Services.Proxy;
 public interface IProxyTrafficFlowService
 {
     void RegisterConnection(ActiveProxyConnection connection, ProxyConnectionIdentity? identity = null);
-    void UnregisterConnection(string connectionId, DateTime? disconnectedAtUtc = null);
+    ProxyTrafficFlowUpdate? UnregisterConnection(string connectionId, DateTime? disconnectedAtUtc = null);
+    bool TryGetTotals(string connectionId, out long clientToServerBytesTotal, out long serverToClientBytesTotal);
     void RegisterConnectFailed(
         string connectionId,
         ProxyConnectionProtocol protocol,

--- a/DataGateOpenVpnManager/Services/Proxy/OpenVpnManagementStatusCache.cs
+++ b/DataGateOpenVpnManager/Services/Proxy/OpenVpnManagementStatusCache.cs
@@ -1,0 +1,85 @@
+using DataGateOpenVpnManager.Services.OpenVpnTelnet;
+
+namespace DataGateOpenVpnManager.Services.Proxy;
+
+public interface IOpenVpnManagementStatusCache
+{
+    OpenVpnManagementStatusSnapshot? GetSnapshot();
+    Task RefreshAsync(CancellationToken cancellationToken);
+}
+
+public sealed record OpenVpnManagementStatusSnapshot(
+    DateTime FetchedAtUtc,
+    string RawStatus,
+    IReadOnlyList<OpenVpnManagementClientEntry> Clients,
+    bool IsValid);
+
+public sealed class OpenVpnManagementStatusCache(
+    OpenVpnManagementSignalService management,
+    IProxySessionAuditService audit,
+    ILogger<OpenVpnManagementStatusCache> logger) : IOpenVpnManagementStatusCache
+{
+    private readonly object _sync = new();
+    private OpenVpnManagementStatusSnapshot? _snapshot;
+
+    public OpenVpnManagementStatusSnapshot? GetSnapshot()
+    {
+        lock (_sync)
+            return _snapshot;
+    }
+
+    public async Task RefreshAsync(CancellationToken cancellationToken)
+    {
+        try
+        {
+            var raw = await management.SendCommandAsync("status 3", cancellationToken);
+            if (raw.StartsWith("Command timed out", StringComparison.Ordinal)
+                || raw.StartsWith("Error while sending command", StringComparison.Ordinal))
+            {
+                logger.LogWarning("[ManagementStatusCache] refresh failed: {Error}", raw);
+                audit.Record(new ProxySessionAuditEntry
+                {
+                    AtUtc = DateTime.UtcNow,
+                    Event = "mgmt.cache.refresh_failed",
+                    Decision = "skip",
+                    Reason = raw
+                });
+                return;
+            }
+
+            var clients = OpenVpnManagementStatusParser.ParseClientList(raw);
+            OpenVpnManagementStatusSnapshot snapshot;
+            lock (_sync)
+            {
+                snapshot = new OpenVpnManagementStatusSnapshot(
+                    DateTime.UtcNow,
+                    raw,
+                    clients,
+                    IsValid: true);
+                _snapshot = snapshot;
+            }
+
+            var details = ProxyAuditDetails.ForSnapshot(snapshot);
+            details["mgmtClients"] = string.Join(',', clients.Select(c => $"{c.CommonName}@{c.RealAddress}"));
+            audit.Record(new ProxySessionAuditEntry
+            {
+                AtUtc = DateTime.UtcNow,
+                Event = "mgmt.cache.refreshed",
+                Decision = "ok",
+                Reason = $"clientCount={clients.Count}",
+                Details = details
+            });
+        }
+        catch (Exception ex) when (ex is not OperationCanceledException)
+        {
+            logger.LogWarning(ex, "[ManagementStatusCache] refresh failed");
+            audit.Record(new ProxySessionAuditEntry
+            {
+                AtUtc = DateTime.UtcNow,
+                Event = "mgmt.cache.refresh_failed",
+                Decision = "error",
+                Reason = ex.Message
+            });
+        }
+    }
+}

--- a/DataGateOpenVpnManager/Services/Proxy/OpenVpnManagementStatusParser.cs
+++ b/DataGateOpenVpnManager/Services/Proxy/OpenVpnManagementStatusParser.cs
@@ -1,0 +1,115 @@
+using System.Globalization;
+using System.Net;
+
+namespace DataGateOpenVpnManager.Services.Proxy;
+
+public sealed record OpenVpnManagementClientEntry(
+    string CommonName,
+    string RealAddress,
+    string VirtualAddress,
+    long BytesReceived,
+    long BytesSent,
+    long ConnectedSinceUnix);
+
+public static class OpenVpnManagementStatusParser
+{
+    public static IReadOnlyList<OpenVpnManagementClientEntry> ParseClientList(string statusResponse)
+    {
+        if (string.IsNullOrWhiteSpace(statusResponse))
+            return Array.Empty<OpenVpnManagementClientEntry>();
+
+        var result = new List<OpenVpnManagementClientEntry>();
+        var lines = statusResponse.Split('\n', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries);
+        foreach (var line in lines)
+        {
+            if (!line.StartsWith("CLIENT_LIST", StringComparison.Ordinal))
+                continue;
+
+            var parts = line.Split('\t');
+            if (parts.Length < 8)
+                continue;
+
+            if (!long.TryParse(parts[5], NumberStyles.Integer, CultureInfo.InvariantCulture, out var bytesReceived))
+                continue;
+            if (!long.TryParse(parts[6], NumberStyles.Integer, CultureInfo.InvariantCulture, out var bytesSent))
+                continue;
+            if (!long.TryParse(parts[7], NumberStyles.Integer, CultureInfo.InvariantCulture, out var connectedSince))
+                connectedSince = 0;
+
+            result.Add(new OpenVpnManagementClientEntry(
+                parts[1],
+                parts[2],
+                parts[3],
+                bytesReceived,
+                bytesSent,
+                connectedSince));
+        }
+
+        return result;
+    }
+
+    public static OpenVpnManagementClientEntry? FindByLocalProxyPort(
+        IEnumerable<OpenVpnManagementClientEntry> clients,
+        string? localProxyIp,
+        int localProxyPort)
+    {
+        foreach (var client in clients)
+        {
+            if (!TryParseRealAddressPort(client.RealAddress, out var ip, out var port))
+                continue;
+            if (port != localProxyPort)
+                continue;
+            if (!LoopbackHostsEqual(localProxyIp, ip))
+                continue;
+
+            return client;
+        }
+
+        return null;
+    }
+
+    internal static bool LoopbackHostsEqual(string? expected, string actual)
+    {
+        var normalizedExpected = NormalizeLoopbackHost(expected);
+        var normalizedActual = NormalizeLoopbackHost(actual);
+        return string.Equals(normalizedExpected, normalizedActual, StringComparison.OrdinalIgnoreCase);
+    }
+
+    internal static string NormalizeLoopbackHost(string? host)
+    {
+        if (string.IsNullOrWhiteSpace(host))
+            return "127.0.0.1";
+
+        var trimmed = host.Trim();
+        if (trimmed.Equals("localhost", StringComparison.OrdinalIgnoreCase))
+            return "127.0.0.1";
+
+        if (!IPAddress.TryParse(trimmed, out var ip))
+            return trimmed;
+
+        if (IPAddress.IsLoopback(ip))
+            return "127.0.0.1";
+
+        return ip.ToString();
+    }
+
+    private static bool TryParseRealAddressPort(string realAddress, out string ip, out int port)
+    {
+        ip = string.Empty;
+        port = 0;
+
+        if (string.IsNullOrWhiteSpace(realAddress))
+            return false;
+
+        var lastColon = realAddress.LastIndexOf(':');
+        if (lastColon <= 0 || lastColon >= realAddress.Length - 1)
+            return false;
+
+        ip = realAddress[..lastColon];
+        if (ip.StartsWith('[') && ip.EndsWith(']'))
+            ip = ip[1..^1];
+
+        return int.TryParse(realAddress[(lastColon + 1)..], NumberStyles.Integer, CultureInfo.InvariantCulture, out port)
+               && port is > 0 and <= 65535;
+    }
+}

--- a/DataGateOpenVpnManager/Services/Proxy/OpenVpnManagementStatusRefreshService.cs
+++ b/DataGateOpenVpnManager/Services/Proxy/OpenVpnManagementStatusRefreshService.cs
@@ -12,6 +12,12 @@ public sealed class OpenVpnManagementStatusRefreshService(
     {
         while (!stoppingToken.IsCancellationRequested)
         {
+            if (!options.Value.NeedsBackgroundManagementRefresh)
+            {
+                await Task.Delay(TimeSpan.FromSeconds(5), stoppingToken);
+                continue;
+            }
+
             var interval = Math.Max(5, options.Value.ManagementStatusRefreshSeconds);
             try
             {

--- a/DataGateOpenVpnManager/Services/Proxy/OpenVpnManagementStatusRefreshService.cs
+++ b/DataGateOpenVpnManager/Services/Proxy/OpenVpnManagementStatusRefreshService.cs
@@ -1,0 +1,32 @@
+using DataGateOpenVpnManager.Models;
+using Microsoft.Extensions.Options;
+
+namespace DataGateOpenVpnManager.Services.Proxy;
+
+public sealed class OpenVpnManagementStatusRefreshService(
+    IOptions<OpenVpnProxyOptions> options,
+    IOpenVpnManagementStatusCache statusCache,
+    ILogger<OpenVpnManagementStatusRefreshService> logger) : BackgroundService
+{
+    protected override async Task ExecuteAsync(CancellationToken stoppingToken)
+    {
+        while (!stoppingToken.IsCancellationRequested)
+        {
+            var interval = Math.Max(5, options.Value.ManagementStatusRefreshSeconds);
+            try
+            {
+                await statusCache.RefreshAsync(stoppingToken);
+                await Task.Delay(TimeSpan.FromSeconds(interval), stoppingToken);
+            }
+            catch (OperationCanceledException) when (stoppingToken.IsCancellationRequested)
+            {
+                break;
+            }
+            catch (Exception ex)
+            {
+                logger.LogWarning(ex, "[ManagementStatusCache] refresh loop failed");
+                await Task.Delay(TimeSpan.FromSeconds(5), stoppingToken);
+            }
+        }
+    }
+}

--- a/DataGateOpenVpnManager/Services/Proxy/ProxyAuditDetails.cs
+++ b/DataGateOpenVpnManager/Services/Proxy/ProxyAuditDetails.cs
@@ -1,0 +1,30 @@
+using System.Globalization;
+using DataGateMonitor.SharedModels.DataGateOpenVpnManager.Proxy;
+
+namespace DataGateOpenVpnManager.Services.Proxy;
+
+internal static class ProxyAuditDetails
+{
+    public static Dictionary<string, string> ForConnection(ActiveProxyConnection connection) =>
+        new()
+        {
+            ["proto"] = connection.Protocol.ToString(),
+            ["local"] = $"{connection.LocalProxyIp}:{connection.LocalProxyPort.ToString(CultureInfo.InvariantCulture)}",
+            ["client"] = $"{connection.RealClientIp}:{connection.RealClientPort.ToString(CultureInfo.InvariantCulture)}",
+            ["connectedAtUtc"] = connection.ConnectedAtUtc.ToString("O", CultureInfo.InvariantCulture)
+        };
+
+    public static Dictionary<string, string> ForSnapshot(OpenVpnManagementStatusSnapshot? snapshot)
+    {
+        if (snapshot is null)
+            return new Dictionary<string, string> { ["cache"] = "null" };
+
+        return new Dictionary<string, string>
+        {
+            ["cacheFetchedAtUtc"] = snapshot.FetchedAtUtc.ToString("O", CultureInfo.InvariantCulture),
+            ["cacheAgeSec"] = Math.Round((DateTime.UtcNow - snapshot.FetchedAtUtc).TotalSeconds, 1)
+                .ToString(CultureInfo.InvariantCulture),
+            ["mgmtClientCount"] = snapshot.Clients.Count.ToString(CultureInfo.InvariantCulture)
+        };
+    }
+}

--- a/DataGateOpenVpnManager/Services/Proxy/ProxyByteComparison.cs
+++ b/DataGateOpenVpnManager/Services/Proxy/ProxyByteComparison.cs
@@ -1,0 +1,29 @@
+namespace DataGateOpenVpnManager.Services.Proxy;
+
+public sealed record ProxyByteComparison(
+    long ProxyClientToServer,
+    long ProxyServerToClient,
+    long ManagementBytesReceived,
+    long ManagementBytesSent,
+    long DeltaClientToServer,
+    long DeltaServerToClient)
+{
+    public static ProxyByteComparison Create(
+        long proxyClientToServer,
+        long proxyServerToClient,
+        long managementBytesReceived,
+        long managementBytesSent)
+    {
+        return new ProxyByteComparison(
+            proxyClientToServer,
+            proxyServerToClient,
+            managementBytesReceived,
+            managementBytesSent,
+            proxyClientToServer - managementBytesReceived,
+            proxyServerToClient - managementBytesSent);
+    }
+
+    public bool HasMaterialDelta(long warnDeltaBytes) =>
+        Math.Abs(DeltaClientToServer) >= warnDeltaBytes
+        || Math.Abs(DeltaServerToClient) >= warnDeltaBytes;
+}

--- a/DataGateOpenVpnManager/Services/Proxy/ProxyByteDebugMonitorService.cs
+++ b/DataGateOpenVpnManager/Services/Proxy/ProxyByteDebugMonitorService.cs
@@ -1,0 +1,77 @@
+using DataGateMonitor.SharedModels.DataGateOpenVpnManager.Proxy;
+using DataGateOpenVpnManager.Models;
+using Microsoft.Extensions.Options;
+
+namespace DataGateOpenVpnManager.Services.Proxy;
+
+public sealed class ProxyByteDebugMonitorService(
+    IOptions<OpenVpnProxyOptions> options,
+    IActiveProxyConnectionService activeConnections,
+    IProxyTrafficFlowService trafficFlow,
+    ProxyByteDebugService byteDebug,
+    ILogger<ProxyByteDebugMonitorService> logger) : BackgroundService
+{
+    protected override async Task ExecuteAsync(CancellationToken stoppingToken)
+    {
+        while (!stoppingToken.IsCancellationRequested)
+        {
+            var opts = options.Value;
+            if (!opts.ByteDebug || opts.ByteDebugIntervalSeconds <= 0)
+            {
+                await Task.Delay(TimeSpan.FromSeconds(5), stoppingToken);
+                continue;
+            }
+
+            try
+            {
+                await Task.Delay(TimeSpan.FromSeconds(opts.ByteDebugIntervalSeconds), stoppingToken);
+                await SnapshotActiveConnectionsAsync(stoppingToken);
+            }
+            catch (OperationCanceledException) when (stoppingToken.IsCancellationRequested)
+            {
+                break;
+            }
+            catch (Exception ex)
+            {
+                logger.LogWarning(ex, "[ProxyByteDebug] periodic snapshot failed");
+            }
+        }
+    }
+
+    private async Task SnapshotActiveConnectionsAsync(CancellationToken cancellationToken)
+    {
+        var connections = activeConnections.GetAll();
+        if (connections.Count == 0)
+            return;
+
+        foreach (var connection in connections)
+        {
+            if (!trafficFlow.TryGetTotals(connection.ConnectionId, out var c2s, out var s2c))
+                continue;
+
+            var update = BuildSnapshotUpdate(connection, c2s, s2c);
+            await byteDebug.CompareAndLogAsync(update, "periodic", cancellationToken);
+        }
+    }
+
+    private static ProxyTrafficFlowUpdate BuildSnapshotUpdate(ActiveProxyConnection connection, long c2s, long s2c) =>
+        new()
+        {
+            ConnectionId = connection.ConnectionId,
+            Protocol = connection.Protocol,
+            State = "connected",
+            IsConnected = true,
+            IsIdle = false,
+            RealClientIp = connection.RealClientIp,
+            RealClientPort = connection.RealClientPort,
+            LocalProxyIp = connection.LocalProxyIp,
+            LocalProxyPort = connection.LocalProxyPort,
+            TargetIp = connection.TargetIp,
+            TargetPort = connection.TargetPort,
+            ClientToServerBytesTotal = c2s,
+            ServerToClientBytesTotal = s2c,
+            ConnectedAtUtc = connection.ConnectedAtUtc,
+            LastActivityAtUtc = DateTime.UtcNow,
+            EmittedAtUtc = DateTime.UtcNow
+        };
+}

--- a/DataGateOpenVpnManager/Services/Proxy/ProxyByteDebugService.cs
+++ b/DataGateOpenVpnManager/Services/Proxy/ProxyByteDebugService.cs
@@ -1,0 +1,138 @@
+using System.Globalization;
+using DataGateOpenVpnManager.Models;
+using Microsoft.Extensions.Options;
+
+namespace DataGateOpenVpnManager.Services.Proxy;
+
+public sealed class ProxyByteDebugService(
+    IOptions<OpenVpnProxyOptions> options,
+    IOpenVpnManagementStatusCache statusCache,
+    IProxySessionAuditService audit,
+    ILogger<ProxyByteDebugService> logger) : IProxyByteDebugService
+{
+    public void ReportDisconnect(ProxyTrafficFlowUpdate update)
+    {
+        if (!options.Value.ByteDebug)
+            return;
+
+        _ = CompareAndLogAsync(update, "disconnect", CancellationToken.None);
+    }
+
+    internal Task CompareAndLogAsync(ProxyTrafficFlowUpdate update, string reason, CancellationToken cancellationToken)
+    {
+        if (update.LocalProxyPort is < 1 or > 65535)
+        {
+            logger.LogInformation(
+                "[ProxyByteDebug] {Reason}: skip connectionId={ConnectionId} — no local proxy port",
+                reason,
+                update.ConnectionId);
+            return Task.CompletedTask;
+        }
+
+        var snapshot = statusCache.GetSnapshot();
+        if (snapshot is null || !snapshot.IsValid)
+        {
+            audit.Record(new ProxySessionAuditEntry
+            {
+                AtUtc = DateTime.UtcNow,
+                Event = "byte_debug.skipped",
+                ConnectionId = update.ConnectionId,
+                Decision = "skip",
+                Reason = $"{reason}: management cache empty"
+            });
+            return Task.CompletedTask;
+        }
+
+        var mgmtClient = OpenVpnManagementStatusParser.FindByLocalProxyPort(
+            snapshot.Clients,
+            update.LocalProxyIp,
+            update.LocalProxyPort);
+
+        if (mgmtClient is null)
+        {
+            var missDetails = ProxyAuditDetails.ForSnapshot(snapshot);
+            missDetails["proxyC2S"] = update.ClientToServerBytesTotal.ToString(CultureInfo.InvariantCulture);
+            missDetails["proxyS2C"] = update.ServerToClientBytesTotal.ToString(CultureInfo.InvariantCulture);
+            audit.Record(new ProxySessionAuditEntry
+            {
+                AtUtc = DateTime.UtcNow,
+                Event = "byte_debug.compared",
+                ConnectionId = update.ConnectionId,
+                Decision = "peer_missing_in_cache",
+                Reason = reason,
+                Details = missDetails
+            });
+            logger.LogWarning(
+                "[ProxyByteDebug] {Reason}: client not in cached management status connectionId={ConnectionId} local={LocalIp}:{LocalPort} proxyC2S={ProxyC2S} proxyS2C={ProxyS2C} cacheAgeSec={CacheAgeSec:F0}",
+                reason,
+                update.ConnectionId,
+                update.LocalProxyIp,
+                update.LocalProxyPort,
+                update.ClientToServerBytesTotal,
+                update.ServerToClientBytesTotal,
+                (DateTime.UtcNow - snapshot.FetchedAtUtc).TotalSeconds);
+            return Task.CompletedTask;
+        }
+
+        var comparison = ProxyByteComparison.Create(
+            update.ClientToServerBytesTotal,
+            update.ServerToClientBytesTotal,
+            mgmtClient.BytesReceived,
+            mgmtClient.BytesSent);
+
+        LogComparison(update, mgmtClient, comparison, reason, snapshot.FetchedAtUtc);
+
+        var okDetails = ProxyAuditDetails.ForSnapshot(snapshot);
+        okDetails["proxyC2S"] = update.ClientToServerBytesTotal.ToString(CultureInfo.InvariantCulture);
+        okDetails["proxyS2C"] = update.ServerToClientBytesTotal.ToString(CultureInfo.InvariantCulture);
+        okDetails["mgmtRecv"] = mgmtClient.BytesReceived.ToString(CultureInfo.InvariantCulture);
+        okDetails["mgmtSent"] = mgmtClient.BytesSent.ToString(CultureInfo.InvariantCulture);
+        okDetails["deltaC2S"] = comparison.DeltaClientToServer.ToString(CultureInfo.InvariantCulture);
+        okDetails["deltaS2C"] = comparison.DeltaServerToClient.ToString(CultureInfo.InvariantCulture);
+        okDetails["cn"] = mgmtClient.CommonName;
+        audit.Record(new ProxySessionAuditEntry
+        {
+            AtUtc = DateTime.UtcNow,
+            Event = "byte_debug.compared",
+            ConnectionId = update.ConnectionId,
+            Decision = "ok",
+            Reason = reason,
+            Details = okDetails
+        });
+
+        return Task.CompletedTask;
+    }
+
+    private void LogComparison(
+        ProxyTrafficFlowUpdate update,
+        OpenVpnManagementClientEntry mgmtClient,
+        ProxyByteComparison comparison,
+        string reason,
+        DateTime cacheFetchedAtUtc)
+    {
+        var warnDelta = options.Value.ByteDebugWarnDeltaBytes;
+        var logLevel = comparison.HasMaterialDelta(warnDelta) ? LogLevel.Warning : LogLevel.Information;
+
+        logger.Log(
+            logLevel,
+            "[ProxyByteDebug] {Reason} connectionId={ConnectionId} proto={Protocol} local={LocalIp}:{LocalPort} client={RealClientIp}:{RealClientPort} cn={CommonName} virt={VirtualAddress} " +
+            "proxyC2S={ProxyC2S} proxyS2C={ProxyS2C} mgmtRecv={MgmtRecv} mgmtSent={MgmtSent} " +
+            "deltaC2S={DeltaC2S} deltaS2C={DeltaS2C} cacheAgeSec={CacheAgeSec:F0} (proxy-mgmt; C2S↔recv, S2C↔sent)",
+            reason,
+            update.ConnectionId,
+            update.Protocol,
+            update.LocalProxyIp,
+            update.LocalProxyPort,
+            update.RealClientIp,
+            update.RealClientPort,
+            mgmtClient.CommonName,
+            mgmtClient.VirtualAddress,
+            comparison.ProxyClientToServer,
+            comparison.ProxyServerToClient,
+            comparison.ManagementBytesReceived,
+            comparison.ManagementBytesSent,
+            comparison.DeltaClientToServer,
+            comparison.DeltaServerToClient,
+            (DateTime.UtcNow - cacheFetchedAtUtc).TotalSeconds);
+    }
+}

--- a/DataGateOpenVpnManager/Services/Proxy/ProxyByteDebugService.cs
+++ b/DataGateOpenVpnManager/Services/Proxy/ProxyByteDebugService.cs
@@ -29,6 +29,17 @@ public sealed class ProxyByteDebugService(
             return Task.CompletedTask;
         }
 
+        return CompareAndLogCoreAsync(update, reason, cancellationToken);
+    }
+
+    private async Task CompareAndLogCoreAsync(
+        ProxyTrafficFlowUpdate update,
+        string reason,
+        CancellationToken cancellationToken)
+    {
+        if (string.Equals(reason, "disconnect", StringComparison.Ordinal))
+            await statusCache.RefreshAsync(cancellationToken);
+
         var snapshot = statusCache.GetSnapshot();
         if (snapshot is null || !snapshot.IsValid)
         {
@@ -40,7 +51,7 @@ public sealed class ProxyByteDebugService(
                 Decision = "skip",
                 Reason = $"{reason}: management cache empty"
             });
-            return Task.CompletedTask;
+            return;
         }
 
         var mgmtClient = OpenVpnManagementStatusParser.FindByLocalProxyPort(
@@ -71,7 +82,7 @@ public sealed class ProxyByteDebugService(
                 update.ClientToServerBytesTotal,
                 update.ServerToClientBytesTotal,
                 (DateTime.UtcNow - snapshot.FetchedAtUtc).TotalSeconds);
-            return Task.CompletedTask;
+            return;
         }
 
         var comparison = ProxyByteComparison.Create(
@@ -99,8 +110,6 @@ public sealed class ProxyByteDebugService(
             Reason = reason,
             Details = okDetails
         });
-
-        return Task.CompletedTask;
     }
 
     private void LogComparison(

--- a/DataGateOpenVpnManager/Services/Proxy/ProxyConnectionLifetimeService.cs
+++ b/DataGateOpenVpnManager/Services/Proxy/ProxyConnectionLifetimeService.cs
@@ -1,0 +1,59 @@
+using System.Collections.Concurrent;
+
+namespace DataGateOpenVpnManager.Services.Proxy;
+
+public sealed class ProxyConnectionLifetimeService(
+    IProxySessionAuditService audit,
+    ILogger<ProxyConnectionLifetimeService> logger) : IProxyConnectionLifetimeService
+{
+    private readonly ConcurrentDictionary<string, CancellationTokenSource> _connections = new();
+
+    public void Register(string connectionId, CancellationTokenSource cancellation)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(connectionId);
+        ArgumentNullException.ThrowIfNull(cancellation);
+        _connections[connectionId] = cancellation;
+    }
+
+    public void Unregister(string connectionId)
+    {
+        if (string.IsNullOrWhiteSpace(connectionId))
+            return;
+
+        _connections.TryRemove(connectionId, out _);
+    }
+
+    public bool TryTerminate(string connectionId, string reason)
+    {
+        if (!_connections.TryRemove(connectionId, out var cancellation))
+            return false;
+
+        if (cancellation.IsCancellationRequested)
+            return true;
+
+        logger.LogWarning(
+            "[ProxyZombie] terminating connectionId={ConnectionId} reason={Reason}",
+            connectionId,
+            reason);
+
+        audit.Record(new ProxySessionAuditEntry
+        {
+            AtUtc = DateTime.UtcNow,
+            Event = "proxy.terminated",
+            ConnectionId = connectionId,
+            Decision = "terminate",
+            Reason = reason
+        });
+
+        try
+        {
+            cancellation.Cancel();
+        }
+        catch (ObjectDisposedException)
+        {
+            // already torn down
+        }
+
+        return true;
+    }
+}

--- a/DataGateOpenVpnManager/Services/Proxy/ProxyManagementPeerDiagnostics.cs
+++ b/DataGateOpenVpnManager/Services/Proxy/ProxyManagementPeerDiagnostics.cs
@@ -1,0 +1,50 @@
+using DataGateMonitor.SharedModels.DataGateOpenVpnManager.Proxy;
+using DataGateOpenVpnManager.Models;
+
+namespace DataGateOpenVpnManager.Services.Proxy;
+
+internal static class ProxyManagementPeerDiagnostics
+{
+    public static bool CanEvaluatePeerPresence(
+        OpenVpnManagementStatusSnapshot? snapshot,
+        OpenVpnProxyOptions options,
+        out string? skipReason)
+    {
+        if (snapshot is null || !snapshot.IsValid)
+        {
+            skipReason = "management_cache_unavailable";
+            return false;
+        }
+
+        var cacheAge = DateTime.UtcNow - snapshot.FetchedAtUtc;
+        var maxCacheAge = TimeSpan.FromSeconds(Math.Max(10, options.ManagementStatusRefreshSeconds * 2));
+        if (cacheAge > maxCacheAge)
+        {
+            skipReason = "management_cache_stale";
+            return false;
+        }
+
+        if (snapshot.Clients.Count == 0)
+        {
+            skipReason = "client_list_empty";
+            return false;
+        }
+
+        skipReason = null;
+        return true;
+    }
+
+    public static bool IsLikelyZombie(
+        ActiveProxyConnection connection,
+        OpenVpnManagementClientEntry? mgmtClient,
+        OpenVpnManagementStatusSnapshot snapshot)
+    {
+        if (mgmtClient is not null)
+            return false;
+
+        if (snapshot.FetchedAtUtc < connection.ConnectedAtUtc)
+            return false;
+
+        return true;
+    }
+}

--- a/DataGateOpenVpnManager/Services/Proxy/ProxySessionAuditService.cs
+++ b/DataGateOpenVpnManager/Services/Proxy/ProxySessionAuditService.cs
@@ -1,0 +1,71 @@
+using DataGateMonitor.SharedModels.DataGateOpenVpnManager.Proxy;
+using DataGateOpenVpnManager.Models;
+using Microsoft.Extensions.Options;
+
+namespace DataGateOpenVpnManager.Services.Proxy;
+
+public interface IProxySessionAuditService
+{
+    void Record(ProxySessionAuditEntry entry);
+    IReadOnlyList<ProxySessionAuditEntry> GetRecent(int limit);
+}
+
+public sealed record ProxySessionAuditEntry
+{
+    public required DateTime AtUtc { get; init; }
+    public required string Event { get; init; }
+    public string? ConnectionId { get; init; }
+    public string? Decision { get; init; }
+    public string? Reason { get; init; }
+    public IReadOnlyDictionary<string, string>? Details { get; init; }
+}
+
+public sealed class ProxySessionAuditService(
+    IOptions<OpenVpnProxyOptions> options,
+    ILogger<ProxySessionAuditService> logger) : IProxySessionAuditService
+{
+    private readonly object _sync = new();
+    private readonly Queue<ProxySessionAuditEntry> _entries = new();
+
+    public void Record(ProxySessionAuditEntry entry)
+    {
+        if (!options.Value.IsSessionAuditEnabled)
+            return;
+
+        var bufferSize = Math.Clamp(options.Value.SessionAuditBufferSize, 50, 5000);
+        lock (_sync)
+        {
+            _entries.Enqueue(entry);
+            while (_entries.Count > bufferSize)
+                _entries.Dequeue();
+        }
+
+        logger.LogInformation(
+            "[ProxyAudit] event={Event} decision={Decision} connectionId={ConnectionId} reason={Reason} {Details}",
+            entry.Event,
+            entry.Decision ?? "-",
+            entry.ConnectionId ?? "-",
+            entry.Reason ?? "-",
+            FormatDetails(entry.Details));
+    }
+
+    public IReadOnlyList<ProxySessionAuditEntry> GetRecent(int limit)
+    {
+        var take = Math.Clamp(limit, 1, 2000);
+        lock (_sync)
+        {
+            if (_entries.Count <= take)
+                return _entries.ToArray();
+
+            return _entries.Skip(_entries.Count - take).ToArray();
+        }
+    }
+
+    private static string FormatDetails(IReadOnlyDictionary<string, string>? details)
+    {
+        if (details is null || details.Count == 0)
+            return string.Empty;
+
+        return string.Join(' ', details.Select(kv => $"{kv.Key}={kv.Value}"));
+    }
+}

--- a/DataGateOpenVpnManager/Services/Proxy/ProxyTrafficFlowService.cs
+++ b/DataGateOpenVpnManager/Services/Proxy/ProxyTrafficFlowService.cs
@@ -32,15 +32,16 @@ public sealed class ProxyTrafficFlowService : IProxyTrafficFlowService
         _connections[connection.ConnectionId] = state;
     }
 
-    public void UnregisterConnection(string connectionId, DateTime? disconnectedAtUtc = null)
+    public ProxyTrafficFlowUpdate? UnregisterConnection(string connectionId, DateTime? disconnectedAtUtc = null)
     {
         if (!_connections.TryRemove(connectionId, out var state))
-            return;
+            return null;
 
         var emittedAt = disconnectedAtUtc ?? DateTime.UtcNow;
+        ProxyTrafficFlowUpdate terminal;
         lock (state.SyncRoot)
         {
-            _terminalUpdates.Enqueue(new ProxyTrafficFlowUpdate
+            terminal = new ProxyTrafficFlowUpdate
             {
                 ConnectionId = state.ConnectionId,
                 Protocol = state.Protocol,
@@ -64,11 +65,30 @@ public sealed class ProxyTrafficFlowService : IProxyTrafficFlowService
                 ConnectedAtUtc = state.ConnectedAtUtc,
                 LastActivityAtUtc = state.LastActivityAtUtc,
                 EmittedAtUtc = emittedAt
-            });
+            };
 
             state.ClientToServerBytesDelta = 0;
             state.ServerToClientBytesDelta = 0;
         }
+
+        _terminalUpdates.Enqueue(terminal);
+        return terminal;
+    }
+
+    public bool TryGetTotals(string connectionId, out long clientToServerBytesTotal, out long serverToClientBytesTotal)
+    {
+        clientToServerBytesTotal = 0;
+        serverToClientBytesTotal = 0;
+        if (!_connections.TryGetValue(connectionId, out var state))
+            return false;
+
+        lock (state.SyncRoot)
+        {
+            clientToServerBytesTotal = state.ClientToServerBytesTotal;
+            serverToClientBytesTotal = state.ServerToClientBytesTotal;
+        }
+
+        return true;
     }
 
     public void RegisterConnectFailed(

--- a/DataGateOpenVpnManager/Services/Proxy/ProxyZombieConnectionMonitorService.cs
+++ b/DataGateOpenVpnManager/Services/Proxy/ProxyZombieConnectionMonitorService.cs
@@ -42,10 +42,7 @@ public sealed class ProxyZombieConnectionMonitorService(
     {
         var opts = options.Value;
         if (opts.CloseZombieAfterMissingSeconds <= 0)
-        {
-            Audit(null, "zombie.check_skipped", "skip", "CloseZombieAfterMissingSeconds=0");
             return;
-        }
 
         var connections = activeConnections.GetAll();
         if (connections.Count == 0)
@@ -56,31 +53,15 @@ public sealed class ProxyZombieConnectionMonitorService(
         }
 
         var snapshot = statusCache.GetSnapshot();
-        if (snapshot is null || !snapshot.IsValid)
+        if (!ProxyManagementPeerDiagnostics.CanEvaluatePeerPresence(snapshot, opts, out var skipReason))
         {
-            Audit(null, "zombie.check_skipped", "skip", "management cache empty", ProxyAuditDetails.ForSnapshot(snapshot));
+            Audit(null, "zombie.check_skipped", "skip", skipReason ?? "peer evaluation unavailable",
+                ProxyAuditDetails.ForSnapshot(snapshot));
             return;
         }
 
         var now = DateTime.UtcNow;
-        var cacheAge = now - snapshot.FetchedAtUtc;
-        var maxCacheAge = TimeSpan.FromSeconds(Math.Max(10, opts.ManagementStatusRefreshSeconds * 2));
-        if (cacheAge > maxCacheAge)
-        {
-            var details = ProxyAuditDetails.ForSnapshot(snapshot);
-            details["maxCacheAgeSec"] = maxCacheAge.TotalSeconds.ToString(CultureInfo.InvariantCulture);
-            Audit(null, "zombie.check_skipped", "skip", "management cache stale", details);
-            return;
-        }
-
-        if (snapshot.Clients.Count == 0)
-        {
-            var details = ProxyAuditDetails.ForSnapshot(snapshot);
-            details["activeProxyCount"] = connections.Count.ToString(CultureInfo.InvariantCulture);
-            Audit(null, "zombie.check_skipped", "skip", "CLIENT_LIST empty while proxy active", details);
-            return;
-        }
-
+        var cacheAge = now - snapshot!.FetchedAtUtc;
         var activeIds = new HashSet<string>(StringComparer.Ordinal);
 
         foreach (var connection in connections)

--- a/DataGateOpenVpnManager/Services/Proxy/ProxyZombieConnectionMonitorService.cs
+++ b/DataGateOpenVpnManager/Services/Proxy/ProxyZombieConnectionMonitorService.cs
@@ -1,0 +1,182 @@
+using System.Collections.Concurrent;
+using System.Globalization;
+using DataGateMonitor.SharedModels.DataGateOpenVpnManager.Proxy;
+using DataGateOpenVpnManager.Models;
+using Microsoft.Extensions.Options;
+
+namespace DataGateOpenVpnManager.Services.Proxy;
+
+public sealed class ProxyZombieConnectionMonitorService(
+    IOptions<OpenVpnProxyOptions> options,
+    IActiveProxyConnectionService activeConnections,
+    IProxyConnectionLifetimeService connectionLifetime,
+    IOpenVpnManagementStatusCache statusCache,
+    IProxySessionAuditService audit,
+    ILogger<ProxyZombieConnectionMonitorService> logger) : BackgroundService
+{
+    private readonly ConcurrentDictionary<string, DateTime> _missingSinceUtc = new();
+    private readonly ConcurrentDictionary<string, int> _consecutiveMisses = new();
+
+    protected override async Task ExecuteAsync(CancellationToken stoppingToken)
+    {
+        while (!stoppingToken.IsCancellationRequested)
+        {
+            var checkInterval = Math.Max(5, options.Value.ZombieCheckIntervalSeconds);
+            try
+            {
+                await Task.Delay(TimeSpan.FromSeconds(checkInterval), stoppingToken);
+                CheckActiveConnections();
+            }
+            catch (OperationCanceledException) when (stoppingToken.IsCancellationRequested)
+            {
+                break;
+            }
+            catch (Exception ex)
+            {
+                logger.LogWarning(ex, "[ProxyZombie] health check failed");
+            }
+        }
+    }
+
+    internal void CheckActiveConnections()
+    {
+        var opts = options.Value;
+        if (opts.CloseZombieAfterMissingSeconds <= 0)
+        {
+            Audit(null, "zombie.check_skipped", "skip", "CloseZombieAfterMissingSeconds=0");
+            return;
+        }
+
+        var connections = activeConnections.GetAll();
+        if (connections.Count == 0)
+        {
+            _missingSinceUtc.Clear();
+            _consecutiveMisses.Clear();
+            return;
+        }
+
+        var snapshot = statusCache.GetSnapshot();
+        if (snapshot is null || !snapshot.IsValid)
+        {
+            Audit(null, "zombie.check_skipped", "skip", "management cache empty", ProxyAuditDetails.ForSnapshot(snapshot));
+            return;
+        }
+
+        var now = DateTime.UtcNow;
+        var cacheAge = now - snapshot.FetchedAtUtc;
+        var maxCacheAge = TimeSpan.FromSeconds(Math.Max(10, opts.ManagementStatusRefreshSeconds * 2));
+        if (cacheAge > maxCacheAge)
+        {
+            var details = ProxyAuditDetails.ForSnapshot(snapshot);
+            details["maxCacheAgeSec"] = maxCacheAge.TotalSeconds.ToString(CultureInfo.InvariantCulture);
+            Audit(null, "zombie.check_skipped", "skip", "management cache stale", details);
+            return;
+        }
+
+        if (snapshot.Clients.Count == 0)
+        {
+            var details = ProxyAuditDetails.ForSnapshot(snapshot);
+            details["activeProxyCount"] = connections.Count.ToString(CultureInfo.InvariantCulture);
+            Audit(null, "zombie.check_skipped", "skip", "CLIENT_LIST empty while proxy active", details);
+            return;
+        }
+
+        var activeIds = new HashSet<string>(StringComparer.Ordinal);
+
+        foreach (var connection in connections)
+        {
+            activeIds.Add(connection.ConnectionId);
+            var details = ProxyAuditDetails.ForConnection(connection);
+            foreach (var kv in ProxyAuditDetails.ForSnapshot(snapshot))
+                details[kv.Key] = kv.Value;
+
+            if (snapshot.FetchedAtUtc < connection.ConnectedAtUtc)
+            {
+                _missingSinceUtc.TryRemove(connection.ConnectionId, out _);
+                _consecutiveMisses.TryRemove(connection.ConnectionId, out _);
+                Audit(connection.ConnectionId, "zombie.peer_check", "skip", "cache older than connection", details);
+                continue;
+            }
+
+            var mgmtClient = OpenVpnManagementStatusParser.FindByLocalProxyPort(
+                snapshot.Clients,
+                connection.LocalProxyIp,
+                connection.LocalProxyPort);
+
+            if (mgmtClient is not null)
+            {
+                _missingSinceUtc.TryRemove(connection.ConnectionId, out _);
+                _consecutiveMisses.TryRemove(connection.ConnectionId, out _);
+                details["cn"] = mgmtClient.CommonName;
+                details["virt"] = mgmtClient.VirtualAddress;
+                Audit(connection.ConnectionId, "zombie.peer_check", "ok", "peer in management", details);
+                continue;
+            }
+
+            var missingSince = _missingSinceUtc.GetOrAdd(connection.ConnectionId, now);
+            var missingFor = now - missingSince;
+            var misses = _consecutiveMisses.AddOrUpdate(connection.ConnectionId, 1, (_, current) => current + 1);
+            details["missingForSec"] = missingFor.TotalSeconds.ToString("F0", CultureInfo.InvariantCulture);
+            details["consecutiveMisses"] = misses.ToString(CultureInfo.InvariantCulture);
+            details["requiredMisses"] = opts.ZombieMinConsecutiveMisses.ToString(CultureInfo.InvariantCulture);
+            details["closeAfterSec"] = opts.CloseZombieAfterMissingSeconds.ToString(CultureInfo.InvariantCulture);
+
+            logger.LogWarning(
+                "[ProxyZombie] OpenVPN peer missing connectionId={ConnectionId} proto={Protocol} local={LocalIp}:{LocalPort} client={RealClientIp}:{RealClientPort} missingForSec={MissingForSec:F0} consecutiveMisses={Misses} cacheAgeSec={CacheAgeSec:F0}",
+                connection.ConnectionId,
+                connection.Protocol,
+                connection.LocalProxyIp,
+                connection.LocalProxyPort,
+                connection.RealClientIp,
+                connection.RealClientPort,
+                missingFor.TotalSeconds,
+                misses,
+                cacheAge.TotalSeconds);
+
+            if (misses < opts.ZombieMinConsecutiveMisses)
+            {
+                Audit(connection.ConnectionId, "zombie.peer_missing", "wait", "consecutive misses below threshold", details);
+                continue;
+            }
+
+            if (missingFor < TimeSpan.FromSeconds(opts.CloseZombieAfterMissingSeconds))
+            {
+                Audit(connection.ConnectionId, "zombie.peer_missing", "wait", "missing duration below threshold", details);
+                continue;
+            }
+
+            Audit(connection.ConnectionId, "zombie.peer_missing", "terminate_requested", "thresholds met", details);
+            if (connectionLifetime.TryTerminate(
+                    connection.ConnectionId,
+                    $"OpenVPN peer missing from management for {missingFor.TotalSeconds:F0}s ({misses} checks)"))
+            {
+                _missingSinceUtc.TryRemove(connection.ConnectionId, out _);
+                _consecutiveMisses.TryRemove(connection.ConnectionId, out _);
+            }
+        }
+
+        foreach (var staleId in _missingSinceUtc.Keys.Where(id => !activeIds.Contains(id)).ToArray())
+        {
+            _missingSinceUtc.TryRemove(staleId, out _);
+            _consecutiveMisses.TryRemove(staleId, out _);
+        }
+    }
+
+    private void Audit(
+        string? connectionId,
+        string eventName,
+        string decision,
+        string reason,
+        Dictionary<string, string>? details = null)
+    {
+        audit.Record(new ProxySessionAuditEntry
+        {
+            AtUtc = DateTime.UtcNow,
+            Event = eventName,
+            ConnectionId = connectionId,
+            Decision = decision,
+            Reason = reason,
+            Details = details
+        });
+    }
+}

--- a/README.md
+++ b/README.md
@@ -72,8 +72,14 @@ Environment variables:
 | `PROTO`                     | Protocol (`udp` or `tcp`)          | `udp`                |
 | `DATA_DIR`                  | Data directory for config/logs/pki | `/mnt`               |
 | `DNS1`, `DNS2`              | Pushed DNS servers                 | `8.8.8.8`, `8.8.4.4` |
+| `MSSFIX`                    | Optional `push "mssfix N"` to clients (WSS/UDP) | _(unset)_ |
 | `VPN_SUBNET`, `VPN_NETMASK` | VPN subnet config                  | `10.51.28.0/24`      |
 | `OpenVpnManagement__Port`   | OpenVPN management interface port  | `5092`               |
+| `OpenVpnProxy__ByteDebug`   | Compare proxy vs management bytes (WSS debug) | `false` |
+| `OpenVpnProxy__ByteDebugIntervalSeconds` | Periodic byte comparison while connected (`0` = on disconnect only) | `0` |
+| `OpenVpnProxy__CloseZombieAfterMissingSeconds` | Close WSS when OpenVPN peer missing from management (`0` = off) | `0` |
+| `OpenVpnProxy__ZombieCheckIntervalSeconds` | How often to check for zombie proxy sessions | `30` |
+| `PROXY_BYTE_DEBUG`          | Legacy alias for `OpenVpnProxy__ByteDebug` (`1` / `true`) | _(unset)_ |
 
 ---
 

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -14,6 +14,8 @@ VPN_NETMASK=${VPN_NETMASK:-255.255.255.0}
 TUN_IF="${TUN_IF:-tun0}"
 WAN_IF="${WAN_IF:-eth0}"
 DCO="${DCO:-false}"
+# Optional push to clients (e.g. 1200 for WSS/UDP tunnels with reduced effective MTU).
+MSSFIX="${MSSFIX:-}"
 
 EASYRSA_DIR="$DATA_DIR/easy-rsa"
 SCRIPT_SOURCE="/scripts"
@@ -113,6 +115,11 @@ if [ "$DCO" = "true" ] || [ "$DCO" = "1" ] || [ "$DCO" = "yes" ]; then
 else
   DCO_OPTION="disable-dco"
 fi
+MSSFIX_LINE=""
+if [ -n "$MSSFIX" ]; then
+  MSSFIX_LINE="push \"mssfix $MSSFIX\""
+  echo "[entrypoint] MSSFIX push enabled: $MSSFIX"
+fi
 cat <<EOF > "$DATA_DIR/server.conf"
 port $PORT
 proto $PROTO
@@ -133,6 +140,7 @@ push "dhcp-option DNS $DNS1"
 push "dhcp-option DNS $DNS2"
 push "block-outside-dns"
 push "redirect-gateway def1"
+${MSSFIX_LINE}
 
 keepalive 15 120
 

--- a/scripts/diagnose-wss-session.sh
+++ b/scripts/diagnose-wss-session.sh
@@ -1,0 +1,131 @@
+#!/usr/bin/env bash
+# One-shot investigation for udp-wss / tcp-wss proxy + OpenVPN + Pi-hole.
+# Run on the VPN host (e.g. dg-telegrambot):
+#   ./scripts/diagnose-wss-session.sh
+#   ./scripts/diagnose-wss-session.sh openvpn-udp-wss 5078 5012 datagate-pihole
+
+set -u
+
+CONTAINER="${1:-openvpn-udp-wss}"
+MGMT_PORT="${2:-5078}"
+API_PORT="${3:-5012}"
+PIHOLE="${4:-datagate-pihole}"
+
+section() {
+  echo
+  echo "===== $1 ====="
+}
+
+mgmt_status3() {
+  ( printf 'status 3\n'; sleep 1; printf 'quit\n' ) | nc -q2 127.0.0.1 "$MGMT_PORT" 2>/dev/null
+}
+
+section "1 APP VERSION"
+if curl -sf "http://127.0.0.1:${API_PORT}/api/info" >/tmp/diag-info.json 2>/dev/null; then
+  grep -oE '"version":"[^"]*"|"Version":"[^"]*"' /tmp/diag-info.json | head -3 || cat /tmp/diag-info.json
+else
+  echo "FAIL: API http://127.0.0.1:${API_PORT}/api/info"
+fi
+
+section "2 OPENVPN MANAGEMENT + PROXY STATE"
+echo "  curl -s http://127.0.0.1:${API_PORT}/api/diagnostics/proxy-sessions | python3 -m json.tool"
+echo "  curl -s 'http://127.0.0.1:${API_PORT}/api/diagnostics/proxy-audit?limit=50' | python3 -m json.tool"
+if curl -sf "http://127.0.0.1:${API_PORT}/api/diagnostics/proxy-sessions" | head -c 2000; then
+  echo
+else
+  echo "proxy-sessions API unavailable (401 until image >=1.2.5.65; use docker logs ProxyAudit below)"
+fi
+echo
+echo "--- last audit events ---"
+if curl -sf "http://127.0.0.1:${API_PORT}/api/diagnostics/proxy-audit?limit=20" | head -c 4000; then
+  echo
+else
+  echo "proxy-audit API unavailable — fallback:"
+  docker logs "$CONTAINER" 2>&1 | grep '\[ProxyAudit\]' | tail -20 || true
+fi
+
+section "3 PROXY LOGS (last 20 ProxyAudit / ProxyByteDebug / ProxyZombie)"
+docker logs "$CONTAINER" 2>&1 | grep -E '\[ProxyAudit\]|ProxyByteDebug|ProxyZombie' | tail -20 || true
+
+section "4 OPENVPN LOG — recent disconnect / timeout / ping"
+docker exec "$CONTAINER" sh -c \
+  'grep -iE "Inactivity timeout|ping-restart|SIGUSR1|Connection reset|MULTI|exit|AUTH FAILED|TLS Error" /openvpn-udp-wss/openvpn.log 2>/dev/null | tail -25' \
+  || echo "(no openvpn.log lines)"
+
+section "5 DNS — host → Pi-hole @10.51.15.1"
+for name in youtube.com googlevideo.com connectivitycheck.gstatic.com; do
+  result="$(dig @"10.51.15.1" "$name" +time=2 +tries=1 +short 2>/dev/null | head -2 | tr '\n' ' ')"
+  if [ -n "$result" ]; then
+    echo "OK  $name -> $result"
+  else
+    echo "FAIL $name (no answer from 10.51.15.1 within 2s)"
+  fi
+done
+
+section "6 L3 — tun1 gateway → tun0 Pi-hole IP"
+if ip -4 addr show dev tun1 2>/dev/null | grep -q 'inet '; then
+  TUN1_GW="$(ip -4 addr show dev tun1 | awk '/inet / {print $2}' | cut -d/ -f1 | head -1)"
+  ping -c 2 -W 1 -I "$TUN1_GW" 10.51.15.1 2>&1 | tail -3
+else
+  echo "SKIP: tun1 has no IPv4 on host"
+fi
+
+section "7 PI-HOLE — container health + recent 10.51.16 queries"
+if docker ps --format '{{.Names}}' | grep -qx "$PIHOLE"; then
+  docker inspect "$PIHOLE" --format 'status={{.State.Status}} health={{if .State.Health}}{{.State.Health.Status}}{{else}}n/a{{end}}'
+  docker logs "$PIHOLE" 2>&1 | grep -E '10\.51\.16\.' | tail -8 || \
+    docker exec "$PIHOLE" sh -c 'grep "10.51.16" /var/log/pihole/pihole.log 2>/dev/null | tail -8' || \
+    echo "(no 10.51.16 queries in recent pihole logs)"
+else
+  echo "FAIL: container $PIHOLE not running"
+fi
+
+section "8 ROUTING / NAT (udp-wss container view)"
+docker exec "$CONTAINER" sh -c 'grep -E "dhcp-option DNS|mssfix" /openvpn-udp-wss/server.conf; echo ---; ip route | grep tun; iptables -t nat -S POSTROUTING | grep 10.51.16' 2>/dev/null
+
+section "9 ZOMBIE CHECK — proxy local ports vs management RealAddress"
+CLIENT_LINES="$(mgmt_status3 | grep -E '^CLIENT_LIST,' || true)"
+MGMT_PORTS="$(echo "$CLIENT_LINES" | awk -F'\t' '{print $3}' | grep -oE '[0-9]+$' | sort -u)"
+PROXY_PORTS="$(docker logs "$CONTAINER" 2>&1 | grep -E '\[ProxyAudit\].*proxy\.connected|\[ProxyAudit\].*local=' \
+  | grep -oE 'local=127\.0\.0\.1:[0-9]+' | tail -5 | sed 's/local=127.0.0.1://' | sort -u)"
+if [ -z "$PROXY_PORTS" ]; then
+  PROXY_PORTS="$(docker logs "$CONTAINER" 2>&1 | grep ProxyByteDebug | grep -oE 'local=127\.0\.0\.1:[0-9]+' \
+    | tail -5 | sed 's/local=127.0.0.1://' | sort -u)"
+fi
+
+if [ -z "$PROXY_PORTS" ]; then
+  echo "No proxy local ports in recent logs"
+else
+  for p in $PROXY_PORTS; do
+    if echo "$MGMT_PORTS" | grep -qx "$p"; then
+      echo "LIVE   proxy port $p — present in management"
+    else
+      echo "ZOMBIE proxy port $p — NOT in management (WSS likely up, OpenVPN dead)"
+    fi
+  done
+fi
+
+section "10 VERDICT"
+LAST_AUDIT="$(docker logs "$CONTAINER" 2>&1 | grep '\[ProxyAudit\]' | tail -1)"
+LAST_BYTE="$(docker logs "$CONTAINER" 2>&1 | grep ProxyByteDebug | tail -1)"
+echo "Last ProxyAudit: ${LAST_AUDIT:-<none>}"
+echo "Last ProxyByteDebug: ${LAST_BYTE:-<none>}"
+
+if echo "$LAST_AUDIT" | grep -q 'proxy.terminated'; then
+  echo ">>> SESSION ENDED: proxy terminated — reconnect client."
+elif echo "$LAST_AUDIT $LAST_BYTE" | grep -q 'client not in management'; then
+  echo ">>> ZOMBIE SESSION: OpenVPN peer gone, WSS proxy still registered."
+elif echo "$LAST_AUDIT" | grep -q 'mgmtClients=.*127.0.0.1'; then
+  echo ">>> LIVE SESSION on server: OpenVPN + proxy registered. If client has no internet,"
+  echo ">>> run sections 5–7 while connected (DNS from 10.51.16.x, Pi-hole queries, tun counters)."
+elif echo "$LAST_BYTE" | grep -q 'mgmtRecv='; then
+  echo ">>> LIVE SESSION: proxy bytes match management. If user still reports hangs, check sections 5–7 (DNS/Pi-hole)."
+else
+  echo ">>> No recent proxy audit — connect VPN and re-run."
+fi
+
+if docker logs "$CONTAINER" 2>&1 | grep -q ProxyZombie; then
+  echo ">>> ProxyZombie killer is active in this image."
+else
+  echo ">>> No ProxyZombie logs yet — either no zombie >=90s or image without zombie killer."
+fi

--- a/scripts/persist-udp-wss-ufw.sh
+++ b/scripts/persist-udp-wss-ufw.sh
@@ -1,0 +1,83 @@
+#!/usr/bin/env bash
+# Persist udp-wss UFW rules on dg-telegrambot-style hosts.
+# Run: sudo ./scripts/persist-udp-wss-ufw.sh
+
+set -euo pipefail
+
+UFW_BEFORE="/etc/ufw/before.rules"
+INPUT_MARKER="# datagate-udp-wss-tun1-input"
+FWD_MARKER="# datagate-udp-wss-tun1-forward"
+
+if [ "$(id -u)" -ne 0 ]; then
+  echo "Run as root: sudo $0"
+  exit 1
+fi
+
+cp -a "$UFW_BEFORE" "${UFW_BEFORE}.bak.$(date +%Y%m%d-%H%M%S)"
+
+python3 <<'PY'
+from pathlib import Path
+
+path = Path("/etc/ufw/before.rules")
+text = path.read_text()
+input_marker = "# datagate-udp-wss-tun1-input"
+fwd_marker = "# datagate-udp-wss-tun1-forward"
+
+fwd_rules = [
+    fwd_marker,
+    "-A ufw-before-forward -i tun1 -o tun0 -j ACCEPT",
+    "-A ufw-before-forward -i tun0 -o tun1 -j ACCEPT",
+    "-A ufw-before-forward -i tun1 -o eth0 -j ACCEPT",
+    "-A ufw-before-forward -i eth0 -o tun1 -j ACCEPT",
+]
+
+input_rules = [
+    input_marker,
+    "-A ufw-before-input -i tun1 -p udp --dport 53 -j ACCEPT",
+    "-A ufw-before-input -i tun1 -p tcp --dport 53 -j ACCEPT",
+]
+
+# Remove mistaken forward rules from *nat block
+lines = text.splitlines(keepends=True)
+out, in_nat = [], False
+for line in lines:
+    if line.startswith("*nat"):
+        in_nat = True
+    if in_nat and line.strip() == "COMMIT":
+        in_nat = False
+    if in_nat and "ufw-before-forward" in line:
+        continue
+    if in_nat and fwd_marker in line:
+        continue
+    out.append(line)
+text = "".join(out)
+
+if input_marker not in text:
+    needle = "-A ufw-before-input -j ufw-not-local\n"
+    block = "".join(r + "\n" for r in input_rules) + "\n"
+    if needle not in text:
+        raise SystemExit("Could not find ufw-not-local anchor in before.rules")
+    text = text.replace(needle, block + needle, 1)
+
+lines = text.splitlines(keepends=True)
+out, in_filter, inserted_fwd = [], False, fwd_marker in text
+for line in lines:
+    if line.startswith("*filter"):
+        in_filter = True
+    if in_filter and not inserted_fwd and line.strip() == "COMMIT":
+        for rule in fwd_rules:
+            out.append(rule + "\n")
+        out.append("\n")
+        inserted_fwd = True
+        in_filter = False
+    out.append(line)
+
+path.write_text("".join(out))
+print("OK: before.rules updated")
+PY
+
+ufw reload
+echo "=== verify ==="
+grep -nE 'datagate-udp-wss|tun1.*53' "$UFW_BEFORE"
+iptables -L ufw-before-input -v -n | grep -E 'tun1|dpt:53' || true
+iptables -L ufw-before-forward -v -n | grep tun1 || true


### PR DESCRIPTION
## Summary
- Serialize OpenVPN management telnet commands via `CommandQueue` mutex to prevent interleaved status-3 responses under concurrent polls.
- Add WSS proxy diagnostics: byte-debug comparison, zombie session monitor, session audit logging, shared management status cache, and `/api/diagnostics/*` HTTP endpoints (localhost allowlist for host-side curl without JWT).
- Add host scripts for UDP-WSS troubleshooting (`diagnose-wss-session.sh`, `persist-udp-wss-ufw.sh`) and document new `OpenVpnProxy__` / MSSFIX environment variables in README.
- Harden review follow-ups: late management reply handling, aligned zombie guards, cache refresh on byte-debug disconnect, idle management polling when debug/zombie are off.
- Expand unit/integration test coverage for proxy services, diagnostics controller, and management cache concurrency. Bump version to 1.2.5.65.

## Test plan
- [ ] `dotnet test` in `DataGateOpenVpnManager.Tests`
- [ ] Deploy to a UDP-WSS host and verify `/api/diagnostics/*` from localhost (no JWT) and from remote (JWT required)
- [ ] Run `scripts/diagnose-wss-session.sh` and confirm checklist output
- [ ] Run `scripts/persist-udp-wss-ufw.sh` on a host with UFW and verify tun1 DNS/forward rules
- [ ] Confirm concurrent status-3 polls no longer produce garbled management responses
- [ ] Verify zombie monitor and byte-debug behave as expected during a live WSS session